### PR TITLE
PASS1-167: Fix import of generate_addresses_task.

### DIFF
--- a/ports/stm32/boards/Passport/modules/tasks/__init__.py
+++ b/ports/stm32/boards/Passport/modules/tasks/__init__.py
@@ -25,6 +25,7 @@ from .erase_passport_task import erase_passport_task
 from .export_summary_task import export_summary_task
 from .format_microsd_task import format_microsd_task
 # from .fcc_copy_files_task import fcc_copy_files_task
+from .generate_addresses_task import generate_addresses_task
 from .get_security_words_task import get_security_words_task
 from .get_seed_words_task import get_seed_words_task
 from .get_backup_code_task import get_backup_code_task


### PR DESCRIPTION
Should allow QR based BTCPay pairing.