### PR TITLE
Pass1-517: passport uses xfp as backup file name

### DIFF
--- a/ports/stm32/boards/Passport/modules/flows/backup_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/backup_flow.py
@@ -24,6 +24,7 @@ class BackupFlow(Flow):
     async def show_intro(self):
         from pages import InfoPage
         from utils import recolor
+        import stash
 
         if self.backup_quiz_passed:
             msgs = ['Passport is about to create an updated microSD backup.',
@@ -34,6 +35,9 @@ class BackupFlow(Flow):
                         recolor(HIGHLIGHT_TEXT_HEX, 'REQUIRED')),
                     'We recommend writing down the Backup Code on the included security card.',
                     'We consider this safe since physical access to the microSD card is required to access the backup.']
+        if stash.bip39_passphrase != '':
+            msgs.append('The current passphrase applied to Passport will not be saved as part of this backup.\n'
+                        'Please ensure you have a robust alternative backup of your passphrase.')
 
         result = await InfoPage(
             icon=lv.LARGE_ICON_BACKUP,

--- a/ports/stm32/boards/Passport/modules/main.py
+++ b/ports/stm32/boards/Passport/modules/main.py
@@ -25,6 +25,7 @@ def go():
     import tasks
     import passport
     from utils import get_screen_brightness
+    import stash
 
     # Initialize the common objects
 
@@ -130,6 +131,9 @@ def go():
     except RuntimeError as e:
         # print("Secure Element Problem: %r" % e)
         pass
+
+    with stash.SensitiveValues() as sv:
+        sv.capture_xpub()
 
     from ui.ui import UI
     from screens import MainScreen

--- a/ports/stm32/boards/Passport/modules/stash.py
+++ b/ports/stm32/boards/Passport/modules/stash.py
@@ -222,6 +222,8 @@ class SensitiveValues:
 
         # Always store these volatile - Takes less than 1 second to recreate, and it will change whenever
         # a passphrase is entered, so no need to waste flash cycles on storing it.
+        if bip39_passphrase == '':
+            settings.set_volatile('root_xfp', xfp)
         settings.set_volatile('xfp', xfp)
         settings.set_volatile('xpub', xpub)
 

--- a/ports/stm32/boards/Passport/modules/tasks/save_backup_task.py
+++ b/ports/stm32/boards/Passport/modules/tasks/save_backup_task.py
@@ -32,7 +32,7 @@ async def save_backup_task(on_done, on_progress, backup_code):
     body = render_backup_contents().encode()
 
     backup_num = 1
-    xfp = xfp2str(settings.get('xfp')).lower()
+    xfp = xfp2str(settings.get('root_xfp')).lower()
     # print('XFP: {}'.format(xfp))
 
     gc.collect()


### PR DESCRIPTION
I added the root_xfp to volatile settings, and added a warning message to the backup info pages if a backup is made while a passphrase is applied.