### PR TITLE
Bad SD Card Causes Crashes

### DIFF
--- a/ports/stm32/boards/Passport/modules/files.py
+++ b/ports/stm32/boards/Passport/modules/files.py
@@ -36,7 +36,7 @@ def _try_microsd(bad_fs_ok=False):
         st = os.statvfs(sd_root)
         return True
     except OSError:
-        pass
+        return False
 
     try:
         sd.power(1)

--- a/ports/stm32/boards/Passport/modules/flows/export_summary_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/export_summary_flow.py
@@ -28,7 +28,6 @@ class ExportSummaryFlow(Flow):
             self.set_result(False)
 
     async def do_export(self):
-        # TODO: should this be done similar to "with CardSlot() as Card"
         if not _try_microsd():
             result = await InsertMicroSDPage().show()
             if not result:

--- a/ports/stm32/boards/Passport/modules/flows/export_summary_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/export_summary_flow.py
@@ -28,6 +28,7 @@ class ExportSummaryFlow(Flow):
             self.set_result(False)
 
     async def do_export(self):
+        # TODO: should this be done similar to "with CardSlot() as Card"
         if not _try_microsd():
             result = await InsertMicroSDPage().show()
             if not result:


### PR DESCRIPTION
This PR is related to PASS1-526, but I don't want to close that issue since there may be more to it still. For now, this should prevent devices from crashing when having issues mounting SD cards.