### PR TITLE
PASS1-527: reduced cooldown time to 50 ms

### DIFF
--- a/ports/stm32/boards/Passport/modpassport_lv-keypad.h
+++ b/ports/stm32/boards/Passport/modpassport_lv-keypad.h
@@ -268,7 +268,7 @@ STATIC void mod_passport_lv_Keypad_read_cb(lv_indev_drv_t* drv, lv_indev_data_t*
     }
 
     if (from_keypad) {
-        if (is_pressed && key_time - key_filter[key_index].release_time < 100) {
+        if (is_pressed && key_time - key_filter[key_index].release_time < 50) {
             key_filter[key_index].eat_next_release = true;
             return;
         }


### PR DESCRIPTION
@FoundationKen suggested that 100ms of cooldown for the same key was too much. 50 ms allows a bit faster pin entry while still preventing most double inputs.