### PR TITLE
Pass1-533: special character passphrases

### DIFF
--- a/ports/stm32/boards/Passport/modules/pages/text_input_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/text_input_page.py
@@ -80,6 +80,9 @@ class TextInputPage(Page):
 
     def left_action(self, is_pressed):
         if not is_pressed:
+            if self.is_showing_symbols:
+                self.is_showing_symbols = False
+                self.update_symbol_picker()
             self.set_result(None)
 
     def attach(self, group):

--- a/ports/stm32/boards/Passport/modules/pages/text_input_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/text_input_page.py
@@ -99,6 +99,7 @@ class TextInputPage(Page):
             if self.symbol_picker is not None:
                 self.symbol_picker.detach()
                 self.symbol_picker.unmount()
+                self.remove_child(self.symbol_picker)
                 self.symbol_picker = None
 
             if self.is_showing_symbols:

--- a/ports/stm32/boards/Passport/modules/views/view.py
+++ b/ports/stm32/boards/Passport/modules/views/view.py
@@ -35,6 +35,10 @@ class View():
             self.children = []
         self.children.append(child)
 
+    def remove_child(self, child):
+        if child in self.children:
+            self.children.remove(child)
+
     def insert_child(self, index, child):
         '''Append a child to the list of children.'''
         if self.children is None:


### PR DESCRIPTION
This memory leak was caused by an item being added to a list every time a special character was selected, and never being removed. I also added a fix for exiting the text_input_page while the symbol_picker was open.