### PR TITLE
Pass1-541: improve sd card error handling

### DIFF
--- a/lib/stm32lib/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd.c
+++ b/lib/stm32lib/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd.c
@@ -343,6 +343,9 @@ HAL_StatusTypeDef HAL_SD_Init(SD_HandleTypeDef *hsd)
     return HAL_ERROR;
   }
 
+  /* Initialize error code before attempting initialization so we don't inherit errors from previous init attempts */
+  hsd->ErrorCode = HAL_SD_ERROR_NONE;
+
   /* Check the parameters */
   assert_param(IS_SDMMC_ALL_INSTANCE(hsd->Instance));
   assert_param(IS_SDMMC_CLOCK_EDGE(hsd->Init.ClockEdge));


### PR DESCRIPTION
This is a fix that wasn't carried forward from the FE repo. I'll keep the linear issue open after this for further SD card fixes, because this didn't solve my SD card problems.