### PR TITLE
Pass1-576: improve FE screen performance

### DIFF
--- a/ports/stm32/boards/Passport/framebuffer.c
+++ b/ports/stm32/boards/Passport/framebuffer.c
@@ -165,7 +165,12 @@ static void _lcd_rounder(lv_disp_drv_t* disp_drv, lv_area_t* area) {
     // The Sharp display only allows writing whole lines, so expand the rectangle to cover the
     // full width of the screen.
     area->x1 = 0;
-    area->x2 = 229;
+    area->x2 = LCD_HOR_RES - 1;
+
+    // LVGL sometimes miscalculates the update region by 1 pixel on the bottom, so we expand the region
+    // It's possible we might expand it more than once when coalescing multiple regions, but this is not
+    // going to affect performance in a noticeable way.
+    area->y2 = MIN(area->y2 + 1, LCD_VER_RES - 1);
 }
 
 uint8_t byte_lookup_table[] = {

--- a/ports/stm32/boards/Passport/framebuffer.c
+++ b/ports/stm32/boards/Passport/framebuffer.c
@@ -89,11 +89,10 @@ void framebuffer_init() {
 #endif  // SCREEN_MODE_MONO
 
     lv_disp_drv_init(disp_drv);
-    disp_drv->hor_res     = LCD_HOR_RES;
-    disp_drv->ver_res     = LCD_VER_RES;
-    disp_drv->draw_buf    = draw_buf;
-    disp_drv->flush_cb    = _lcd_flush;
-    disp_drv->direct_mode = 1;
+    disp_drv->hor_res  = LCD_HOR_RES;
+    disp_drv->ver_res  = LCD_VER_RES;
+    disp_drv->draw_buf = draw_buf;
+    disp_drv->flush_cb = _lcd_flush;
 #ifdef SCREEN_MODE_COLOR
     memcpy(&_small_lcd_disp_drv, &_big_lcd_disp_drv, sizeof(lv_disp_drv_t));
     _small_lcd_disp_drv.draw_buf    = &_small_lcd_draw_buf;
@@ -161,12 +160,23 @@ static void _lcd_flush(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_
 }
 
 #ifdef SCREEN_MODE_MONO
+
 static void _lcd_rounder(lv_disp_drv_t* disp_drv, lv_area_t* area) {
+    // The Sharp display only allows writing whole lines, so expand the rectangle to cover the
+    // full width of the screen.
     area->x1 = 0;
     area->x2 = 229;
-    area->y1 = 0;
-    area->y2 = 302;
 }
+
+uint8_t byte_lookup_table[] = {
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1,
+    128, 64, 32, 16, 8, 4};
 
 static void _lcd_set_px(lv_disp_drv_t* disp_drv,
                         uint8_t*       buf,
@@ -177,10 +187,12 @@ static void _lcd_set_px(lv_disp_drv_t* disp_drv,
                         lv_opa_t       opa) {
     buf += 30 * y;
     buf += x >> 3;
-    if (lv_color_brightness(color) > 128) {
-        (*buf) |= (1 << (7 - (x & 0x07)));
+    uint8_t byte_value = byte_lookup_table[x];
+
+    if (lv_color_brightness(color) > 96) {
+        (*buf) |= byte_value;
     } else {
-        (*buf) &= ~(1 << (7 - (x & 0x07)));
+        (*buf) &= ~byte_value;
     }
 }
 #endif  // SCREEN_MODE_MONO

--- a/ports/stm32/boards/Passport/include/lcd-sharp-ls018b7dh02.h
+++ b/ports/stm32/boards/Passport/include/lcd-sharp-ls018b7dh02.h
@@ -48,16 +48,17 @@ typedef struct _LCDTestScreen {
 #define COLOR_BLACK 0
 #define COLOR_WHITE 1
 
-void lcd_init(bool clear);
-void lcd_deinit(void);
-void lcd_fill(uint16_t color);
-void lcd_clear(uint16_t color);
-void lcd_update(bool invert);
-void lcd_update_rect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* data);
-void lcd_draw_glyph(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* glyph, uint16_t color);
-void lcd_draw_image(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* image);
+void     lcd_init(bool clear);
+void     lcd_deinit(void);
+void     lcd_fill(uint16_t color);
+void     lcd_clear(uint16_t color);
+void     lcd_update(bool invert);
+void     lcd_update_rect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* data);
+void     lcd_update_viewfinder(uint8_t* grayscale, uint16_t gray_hor_res, uint16_t gray_ver_res);
+void     lcd_draw_glyph(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* glyph, uint16_t color);
+void     lcd_draw_image(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint8_t* image);
 uint16_t lcd_get_glyph_pixel(int16_t x, int16_t y, uint16_t w, uint16_t h, uint8_t* image);
 uint16_t lcd_get_image_pixel(int16_t x, int16_t y, uint16_t w, uint16_t h, uint8_t* image, uint16_t default_color);
-void lcd_set_pixel(int16_t x, int16_t y, uint16_t color);
+void     lcd_set_pixel(int16_t x, int16_t y, uint16_t color);
 
 #endif /* __LCD_SHARP_H__ */

--- a/ports/stm32/boards/Passport/modpassport_lv-lcd.h
+++ b/ports/stm32/boards/Passport/modpassport_lv-lcd.h
@@ -20,8 +20,29 @@ STATIC mp_obj_t mod_passport_lv_lcd_init(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_passport_lv_lcd_init_obj, mod_passport_lv_lcd_init);
 
+#ifdef SCREEN_MODE_MONO
+STATIC mp_obj_t mod_passport_lv_lcd_update_viewfinder_direct(size_t n_args, const mp_obj_t* args) {
+    mp_buffer_info_t grayscale_info;
+    mp_get_buffer_raise(args[0], &grayscale_info, MP_BUFFER_READ);
+
+    mp_int_t hor_res = mp_obj_get_int(args[1]);
+    mp_int_t ver_res = mp_obj_get_int(args[2]);
+
+    lcd_update_viewfinder(grayscale_info.buf, hor_res, ver_res);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_passport_lv_lcd_update_viewfinder_direct_obj,
+                                           3,
+                                           3,
+                                           mod_passport_lv_lcd_update_viewfinder_direct);
+#endif
+
 STATIC const mp_rom_map_elem_t mod_passport_lv_lcd_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&mod_passport_lv_lcd_init_obj)},
+#ifdef SCREEN_MODE_MONO
+    {MP_ROM_QSTR(MP_QSTR_update_viewfinder_direct), MP_ROM_PTR(&mod_passport_lv_lcd_update_viewfinder_direct_obj)},
+#endif
 };
 STATIC MP_DEFINE_CONST_DICT(mod_passport_lv_lcd_globals, mod_passport_lv_lcd_globals_table);
 

--- a/ports/stm32/boards/Passport/modules/constants.py
+++ b/ports/stm32/boards/Passport/modules/constants.py
@@ -140,7 +140,7 @@ def set_gen1_constants():
     # Display constants
     # TODO: Can we reference Display.HEIGHT here instead of 303?
     STATUSBAR_HEIGHT = 40
-    CARD_PAD_BOTTOM = 28
+    CARD_PAD_BOTTOM = 26
     CARD_PAD_LEFT = 4
     CARD_PAD_RIGHT = 4
     OUTER_CORNER_RADIUS = 16

--- a/ports/stm32/boards/Passport/modules/display.py
+++ b/ports/stm32/boards/Passport/modules/display.py
@@ -44,7 +44,7 @@ class Display:
         HALF_WIDTH = WIDTH // 2
         HEIGHT = 303
         HALF_HEIGHT = HEIGHT // 2
-        HEADER_HEIGHT = 40
+        HEADER_HEIGHT = 38
         FOOTER_HEIGHT = 32
         SCROLLBAR_WIDTH = 8
         NUM_LVGL_BUF_LINES = HEIGHT

--- a/ports/stm32/boards/Passport/modules/pages/scan_qr_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/scan_qr_page.py
@@ -58,9 +58,13 @@ class ScanQRPage(Page):
         else:
             # Camera needs to be a square on Founders Edition so that the rotation
             # works properly.
-            self.camera.set_width(180)
-            self.camera.set_height(180)
-        self.camera.set_y(-22)
+            self.camera.set_width(188)
+            self.camera.set_height(188)
+
+        if passport.IS_COLOR:
+            self.camera.set_y(-22)
+        else:
+            self.camera.set_y(-12)
         self.set_scroll_dir(dir=lv.DIR.NONE)
         with Stylize(self.camera) as default:
             default.align(lv.ALIGN.CENTER)
@@ -73,7 +77,9 @@ class ScanQRPage(Page):
             if passport.IS_COLOR:
                 default.pad(bottom=8)
             else:
-                default.pad(bottom=2)
+                # self.progress_label.set_y(0)
+                default.pad(bottom=0)
+
         self.set_children([self.camera, self.progress_label])
 
     def attach(self, group):

--- a/ports/stm32/boards/Passport/modules/pages/scan_qr_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/scan_qr_page.py
@@ -70,7 +70,10 @@ class ScanQRPage(Page):
         self.progress_label = Label(text=progress_text(0), color=TEXT_GREY)
         with Stylize(self.progress_label) as default:
             default.align(lv.ALIGN.BOTTOM_MID)
-            default.pad(bottom=8)
+            if passport.IS_COLOR:
+                default.pad(bottom=8)
+            else:
+                default.pad(bottom=2)
         self.set_children([self.camera, self.progress_label])
 
     def attach(self, group):

--- a/ports/stm32/boards/Passport/modules/views/camera.py
+++ b/ports/stm32/boards/Passport/modules/views/camera.py
@@ -72,9 +72,14 @@ class Camera(View):
         # full access to the buffer.
         self.hook()
 
-        # Resize the framebuffer and invalidate the widget contents, so it gets redrawn.
-        camera.resize(self.content_width, self.content_height)
-        self.lvgl_root.invalidate()
+        if passport.IS_COLOR or passport.IS_SIMULATOR:
+            # Resize the framebuffer and invalidate the widget contents, so it gets redrawn.
+            camera.resize(self.content_width, self.content_height)
+            self.lvgl_root.invalidate()
+        else:  # MONO device
+            # Update the viewfinder using the grayscale image in the QR framebuffer
+            import passport_lv
+            passport_lv.lcd.update_viewfinder_direct(qr.framebuffer, self.HOR_RES, self.VER_RES)
 
     def enable(self):
         """Enable the camera"""

--- a/ports/stm32/boards/Passport/modules/views/camera.py
+++ b/ports/stm32/boards/Passport/modules/views/camera.py
@@ -9,6 +9,8 @@ import passport
 from foundation import qr
 from passport import camera
 from views import View
+from styles import Stylize
+from styles.colors import WHITE
 from data_codecs.qr_factory import get_qr_decoder_for_data
 
 
@@ -42,8 +44,16 @@ class Camera(View):
         self.content_height = None
         self.img_dsc = None
 
+        if not passport.IS_COLOR and not passport.IS_SIMULATOR:
+            with Stylize(self) as default:
+                default.bg_color(WHITE)
+                default.border_width(0)
+
     def create_lvgl_root(self, lvgl_parent):  # noqa
-        return lv.img(lvgl_parent)
+        if passport.IS_COLOR or passport.IS_SIMULATOR:
+            return lv.img(lvgl_parent)
+        else:
+            return lv.obj(lvgl_parent)
 
     def hook(self):
         pass
@@ -97,7 +107,13 @@ class Camera(View):
             # complete area). The pixel format of the camera is the same one as the
             # LVGL format.
             self._framebuffer = camera.framebuffer()
+
+            # Nothing else to do on device since viewfinder is hard-wired at the lower level
+            if not passport.IS_COLOR and not passport.IS_SIMULATOR:
+                return
+
             self.lvgl_root.refr_size()
+
             self.content_width = min(self.content_width, self.HOR_RES)
             self.content_height = min(self.content_height, self.VER_RES)
             self.img_dsc = lv.img_dsc_t({
@@ -109,9 +125,6 @@ class Camera(View):
                 'data': self._framebuffer,
             })
             self.lvgl_root.set_src(self.img_dsc)
-            if not passport.IS_COLOR and not passport.IS_SIMULATOR:
-                self.lvgl_root.set_pivot(self.content_width // 2, self.content_height // 2)
-                self.lvgl_root.set_angle(900)
         else:
             self.content_width = None
             self.content_height = None


### PR DESCRIPTION
Instead of letting LVGL render pixel-by-pixel from the camera image downsampled to 1 bit-per-pixel, we now render directly to the LCD driver buffer and update just the modified lines.

In addition, the LVGL `_lcd_rounder` callback was always setting the fully display to be updated (in addition to setting `direct_mode=1`, which ended up doing the same thing).  Change it so that only the dirty lines are push to the display.  Also optimized the bit calculation of `_lcd_set_px()` to be a table lookup instead for a small LVGL performance boost.