### PR TITLE
SFT-1842: Fix ChooserPage item scroll behavior

### DIFF
--- a/ports/stm32/boards/Passport/modules/pages/auto_shutdown_setting_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/auto_shutdown_setting_page.py
@@ -23,4 +23,5 @@ class AutoShutdownSettingPage(SettingPage):
             statusbar=statusbar,
             setting_name='shutdown_timeout',
             options=self.OPTIONS,
-            default_value=self.OPTIONS[2].get('value'))
+            default_value=self.OPTIONS[2].get('value'),
+            scroll_fix=True)

--- a/ports/stm32/boards/Passport/modules/pages/brightness_setting_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/brightness_setting_page.py
@@ -6,6 +6,7 @@
 
 from pages import SettingPage
 from utils import get_screen_brightness, set_screen_brightness
+import passport
 import common
 
 
@@ -25,7 +26,8 @@ class BrightnessSettingPage(SettingPage):
             setting_name='screen_brightness',  # NOTE: Not actually used for this setting as we store it in EEPROM
             options=self.OPTIONS,
             default_value=self.OPTIONS[4].get('value'),
-            on_change=self.on_change)
+            on_change=self.on_change,
+            scroll_fix=not passport.IS_COLOR)
 
     def on_change(self, new_value):
         common.display.set_brightness(new_value)

--- a/ports/stm32/boards/Passport/modules/pages/chooser_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/chooser_page.py
@@ -21,7 +21,7 @@ import common
 class ChooserPage(Page):
     def __init__(
             self, card_header=None, statusbar=None, options=[],
-            initial_value=None, on_change=None,
+            initial_value=None, on_change=None, scroll_fix=False,
             icon=None, icon_color=CHOOSER_ICON, text=None, center=False, item_icon=lv.ICON_SMALL_CHECKMARK,
             left_micron=microns.Cancel, right_micron=microns.Checkmark):
 
@@ -37,13 +37,15 @@ class ChooserPage(Page):
         self.options = options
         self.initial_value = initial_value
         self.on_change = on_change
+        # This is only required to be True if you have a chooser which has too many items to fit on the screen.
+        self.scroll_fix = scroll_fix
         self.icon = icon
         self.icon_color = icon_color
         self.text = text
         self.center = center
         self.item_icon = item_icon
 
-        # If initial value is given, then select it, else o
+        # If initial value is given, then select it, else select the first item
         if self.initial_value is not None:
             self.selected_idx = self.get_selected_option_index_by_value(self.initial_value)
         else:
@@ -118,7 +120,8 @@ class ChooserPage(Page):
         if initial_focus is not None:
             lv.gridnav_set_focused(self.scroll_container.lvgl_root, initial_focus, False)
 
-        self.scroll_to_selected_option()
+        if self.scroll_fix:
+            self.scroll_selected_to_visible()
 
     def detach(self):
         lv.group_remove_obj(self.scroll_container.lvgl_root)
@@ -127,7 +130,7 @@ class ChooserPage(Page):
         self.scroll_container.set_no_scroll()
         super().detach()
 
-    def scroll_to_selected_option(self):
+    def scroll_selected_to_visible(self):
         """Scrolls the menu list to make the selected option visible."""
         selected = self.scroll_container.children[self.selected_idx].get_lvgl_root()
         if selected is not None:

--- a/ports/stm32/boards/Passport/modules/pages/setting_page.py
+++ b/ports/stm32/boards/Passport/modules/pages/setting_page.py
@@ -9,7 +9,7 @@ import common
 
 class SettingPage(ChooserPage):
     def __init__(self, card_header=None, statusbar=None, options=[],
-                 setting_name=None, default_value=None, on_change=None):
+                 setting_name=None, default_value=None, on_change=None, scroll_fix=False):
         self.setting_name = setting_name
         self.default_value = default_value
 
@@ -18,7 +18,8 @@ class SettingPage(ChooserPage):
             statusbar=statusbar,
             options=options,
             initial_value=self.get_setting(),
-            on_change=self._on_setting_change)
+            on_change=self._on_setting_change,
+            scroll_fix=scroll_fix)
 
         self.on_setting_change = on_change
 


### PR DESCRIPTION
Only the AutoShutdownSettingPage needs the special scroll-to-visible fix.  It causes problems on other pages that use the forced scrolling.