### PR TITLE
SFT-2113: Only create backup folder inside CardSlot context

### DIFF
--- a/ports/stm32/boards/Passport/modules/flows/save_to_microsd_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/save_to_microsd_flow.py
@@ -38,12 +38,11 @@ class SaveToMicroSDFlow(Flow):
 
         written = False
 
-        if self.path:
-            ensure_folder_exists(self.path)
-
         for path in [self.path, None]:
             try:
                 with CardSlot() as card:
+                    ensure_folder_exists(self.path)
+
                     self.out_full, _ = card.pick_filename(self.filename, path)
 
                     if self.data:


### PR DESCRIPTION
Folder is properly created now if it does not exist.