### PR TITLE
UPDATE: copy on validate url for tampering.

### DIFF
--- a/ports/stm32/boards/Passport/modules/flows/scv_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/scv_flow.py
@@ -41,7 +41,7 @@ class ScvFlow(Flow):
         else:
             messages = [{'text': 'Let\'s confirm Passport was not tampered with during shipping.'},
                         {'text': 'Next, scan the Security Check '
-                         'QR code from validate.foundationdevices.com.'}]
+                         'QR code from https://validate.foundationdevices.com.'}]
 
         result = await SeriesOfPagesFlow(ShieldPage, messages).run()
 


### PR DESCRIPTION
Currently the formatting of the URL doesn't fit on a single line which may confuse the user to misread the full url.  By putting https:// in front of the URL, the user will have a better understanding of where the URL begins.