### PR TITLE
SFT-3480: Add firmware image signature verification

### DIFF
--- a/extmod/foundation-rust/Cargo.lock
+++ b/extmod/foundation-rust/Cargo.lock
@@ -18,28 +18,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative 0.1.2",
-]
-
-[[package]]
 name = "bitcoin_hashes"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "hex-conservative 0.2.1",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -120,9 +104,10 @@ dependencies = [
 name = "foundation"
 version = "0.1.0"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "cortex-m",
  "critical-section",
+ "foundation-firmware",
  "foundation-ur",
  "foundation-urtypes",
  "heapless",
@@ -141,12 +126,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6bdea1eeaa5edb5355234d02f81c6dbdd4bc5146887990dd29a213029bbeae"
 
 [[package]]
+name = "foundation-firmware"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a0d5d35a9470dea4fc94d5b04fafdf587d4c642e1f8de97879bb0f99fff96a"
+dependencies = [
+ "bitcoin_hashes",
+ "heapless",
+ "nom",
+ "secp256k1",
+]
+
+[[package]]
 name = "foundation-ur"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ead93a082dfa0a11c2bb43242a1cdc93b1e7976d768465b54a0703dbd3b003"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes",
  "crc",
  "heapless",
  "itertools",
@@ -206,12 +203,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
-
-[[package]]
-name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
@@ -235,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "minicbor"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +271,16 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "once_cell"

--- a/extmod/foundation-rust/Cargo.toml
+++ b/extmod/foundation-rust/Cargo.toml
@@ -12,7 +12,7 @@ name = "sizes"
 required-features = ["std"]
 
 [dependencies.bitcoin_hashes]
-version = "0.13"
+version = "0.14"
 features = ["small-hash"]
 default-features = false
 
@@ -26,6 +26,10 @@ default-features = false
 
 [dependencies.uuid]
 version = "1"
+default-features = false
+
+[dependencies.foundation-firmware]
+version = "0.1"
 default-features = false
 
 [dependencies.foundation-ur]

--- a/extmod/foundation-rust/src/firmware.rs
+++ b/extmod/foundation-rust/src/firmware.rs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2024 Foundation Devices, Inc. <hello@foundationdevices.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::secp256k1::PRE_ALLOCATED_CTX;
+use bitcoin_hashes::{sha256d, Hash};
+use core::{ffi::c_char, slice};
+use foundation_firmware::{VerifyHeaderError, VerifySignatureError};
+use secp256k1::PublicKey;
+
+pub const VERSION_LEN: usize = 8;
+
+/// The result of the firmware update verification.
+/// cbindgen:rename-all=ScreamingSnakeCase
+/// cbindgen:prefix-with-name
+#[repr(C)]
+pub enum FirmwareResult {
+    // Header.
+    /// The firmware validation succeed.
+    HeaderOk {
+        version: [c_char; VERSION_LEN],
+        signed_by_user: bool,
+    },
+    /// The header format is not valid.
+    InvalidHeader,
+    /// Unknown magic number.
+    UnknownMagic { magic: u32 },
+    /// The timestamp field is invalid.
+    InvalidTimestamp,
+    /// The firmware is too small.
+    TooSmall { len: u32 },
+    /// The firmware is too big.
+    TooBig { len: u32 },
+    /// The firmware is older than the current firmware.
+    TooOld {
+        timestamp: u32,
+        // version: *const c_char,
+    },
+    /// Public Key 1 is out of range.
+    InvalidPublicKey1Index { index: u32 },
+    /// Public Key 2 is out of range.
+    InvalidPublicKey2Index { index: u32 },
+    /// The same public key was used for the two signatures.
+    SamePublicKey {
+        /// Index of the duplicated key.
+        index: u32,
+    },
+    // Signatures.
+    /// Signature verification succeed.
+    SignaturesOk,
+    /// The user signed firmware is not valid.
+    InvalidUserSignature,
+    /// The first signature verification failed.
+    FailedSignature1,
+    /// The second signature verification failed.
+    FailedSignature2,
+}
+
+impl From<VerifyHeaderError> for FirmwareResult {
+    fn from(e: VerifyHeaderError) -> Self {
+        use FirmwareResult::*;
+
+        match e {
+            VerifyHeaderError::UnknownMagic(magic) => UnknownMagic { magic },
+            VerifyHeaderError::InvalidTimestamp => InvalidTimestamp,
+            VerifyHeaderError::FirmwareTooSmall(len) => TooSmall { len },
+            VerifyHeaderError::FirmwareTooBig(len) => TooBig { len },
+            VerifyHeaderError::InvalidPublicKey1Index(index) => {
+                InvalidPublicKey1Index { index }
+            }
+            VerifyHeaderError::InvalidPublicKey2Index(index) => {
+                InvalidPublicKey2Index { index }
+            }
+            VerifyHeaderError::SamePublicKeys(index) => SamePublicKey { index },
+        }
+    }
+}
+
+impl From<VerifySignatureError> for FirmwareResult {
+    fn from(e: VerifySignatureError) -> Self {
+        use FirmwareResult::*;
+
+        match e {
+            VerifySignatureError::InvalidUserSignature { .. } => {
+                InvalidUserSignature
+            }
+            VerifySignatureError::FailedSignature1 { .. } => FailedSignature1,
+            VerifySignatureError::FailedSignature2 { .. } => FailedSignature2,
+            // No need to implement this, see comment on
+            // verify_update_signatures.
+            VerifySignatureError::MissingUserPublicKey => unimplemented!(),
+        }
+    }
+}
+
+fn verify_update_header_impl(
+    header: &[u8],
+    current_timestamp: u32,
+    result: &mut FirmwareResult,
+) -> Option<foundation_firmware::Header> {
+    let header = match foundation_firmware::header(header) {
+        Ok((_, header)) => header,
+        Err(_) => {
+            *result = FirmwareResult::InvalidHeader;
+            return None;
+        }
+    };
+
+    if let Err(e) = header.verify() {
+        *result = FirmwareResult::from(e);
+        return None;
+    }
+
+    if header.information.timestamp < current_timestamp {
+        *result = FirmwareResult::TooOld {
+            timestamp: header.information.timestamp,
+        };
+        return None;
+    }
+
+    Some(header)
+}
+
+/// Verify the header of a firmware update.
+#[export_name = "foundation_firmware_verify_update_header"]
+pub extern "C" fn verify_update_header(
+    header: *const u8,
+    header_len: usize,
+    current_timestamp: u32,
+    result: &mut FirmwareResult,
+) {
+    let header = unsafe { slice::from_raw_parts(header, header_len) };
+
+    match verify_update_header_impl(header, current_timestamp, result) {
+        Some(header) => {
+            let version_bytes = header.information.version.as_bytes();
+            let mut version = [0; VERSION_LEN];
+            for (i, &b) in version_bytes.iter().enumerate() {
+                version[i] = b as c_char;
+            }
+            version[version_bytes.len()] = b'\0' as c_char;
+
+            *result = FirmwareResult::HeaderOk {
+                version,
+                signed_by_user: header.is_signed_by_user(),
+            };
+        }
+        // Verification failed.
+        None => (),
+    }
+}
+
+#[export_name = "foundation_firmware_verify_update_signatures"]
+pub extern "C" fn verify_update_signatures(
+    header: *const u8,
+    header_len: usize,
+    current_timestamp: u32,
+    hash: &[u8; 32],
+    user_public_key: Option<&[u8; 64]>,
+    result: &mut FirmwareResult,
+) {
+    let header = unsafe { slice::from_raw_parts(header, header_len) };
+    let firmware_hash = sha256d::Hash::from_slice(hash)
+        .expect("hash should be of correct length");
+
+    let user_public_key = user_public_key
+        .map(|v| {
+            let mut buf = [0; 65];
+            buf[0] = 0x04;
+            (&mut buf[1..]).copy_from_slice(v);
+            buf
+        })
+        .map(|v| {
+            PublicKey::from_slice(&v).expect("user public key should be valid")
+        });
+
+    let header =
+        match verify_update_header_impl(header, current_timestamp, result) {
+            Some(header) => header,
+            None => return,
+        };
+
+    match foundation_firmware::verify_signature(
+        &PRE_ALLOCATED_CTX,
+        &header,
+        &firmware_hash,
+        user_public_key.as_ref(),
+    ) {
+        Ok(()) => {
+            *result = FirmwareResult::SignaturesOk;
+        }
+        // The code calling this function must make sure that there's an user
+        // public key provided to us before verifying signatures.
+        //
+        // When verifying signatures is because we are committed to the
+        // update, i.e. the user has accepted to do it, so we must have
+        // presented an error if there was not an user public key earlier.
+        Err(VerifySignatureError::MissingUserPublicKey) => {
+            unreachable!("we always provide a user public key")
+        }
+        Err(e) => *result = FirmwareResult::from(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity_test() {
+        assert_eq!(VERSION_LEN, foundation_firmware::VERSION_LEN);
+    }
+}

--- a/extmod/foundation-rust/src/lib.rs
+++ b/extmod/foundation-rust/src/lib.rs
@@ -7,6 +7,7 @@
 #[cfg(target_arch = "arm")]
 use cortex_m as _;
 
+pub mod firmware;
 pub mod secp256k1;
 pub mod ur;
 

--- a/extmod/foundation-rust/src/secp256k1.rs
+++ b/extmod/foundation-rust/src/secp256k1.rs
@@ -12,7 +12,7 @@ use secp256k1::{
 static mut PRE_ALLOCATED_CTX_BUF: [AlignedType; 20] = [AlignedType::ZERO; 20];
 
 /// cbindgen:ignore
-static PRE_ALLOCATED_CTX: Lazy<Secp256k1<AllPreallocated<'static>>> =
+pub static PRE_ALLOCATED_CTX: Lazy<Secp256k1<AllPreallocated<'static>>> =
     Lazy::new(|| {
         // SAFETY:
         //

--- a/ports/stm32/boards/Passport/manifest.py
+++ b/ports/stm32/boards/Passport/manifest.py
@@ -287,7 +287,8 @@ freeze('$(MPY_DIR)/ports/stm32/boards/Passport/modules',
         'tasks/sign_text_file_task.py',
         'tasks/validate_electrum_message_task.py',
         'tasks/validate_psbt_task.py',
-        'tasks/verify_backup_task.py'))
+        'tasks/verify_backup_task.py',
+        'tasks/verify_firmware_signature_task.py'))
 
 # Translations
 freeze('$(MPY_DIR)/ports/stm32/boards/Passport/modules',

--- a/ports/stm32/boards/Passport/modpassport.c
+++ b/ports/stm32/boards/Passport/modpassport.c
@@ -21,6 +21,8 @@
 
 /// package: passport
 
+STATIC MP_DEFINE_EXCEPTION(InvalidFirmwareUpdate, Exception);
+
 /// def supply_chain_challenge(self, challenge: bytearray, response: bytearray) -> boolean:
 ///     """
 ///     Perform the supply chain challenge (HMAC)
@@ -61,13 +63,198 @@ STATIC mp_obj_t mod_passport_verify_supply_chain_server_signature(mp_obj_t hash_
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_passport_verify_supply_chain_server_signature_obj,
                                  mod_passport_verify_supply_chain_server_signature);
 
+/// def verify_update_header(self, header: bytearray) -> None:
+///     '''
+///     Verify the given firmware header bytes as a potential candidate to be
+///     installed.
+///     '''
+STATIC mp_obj_t mod_passport_verify_update_header(mp_obj_t header) {
+    mp_obj_t tuple[2];
+
+    mp_buffer_info_t header_info;
+    mp_get_buffer_raise(header, &header_info, MP_BUFFER_READ);
+
+    // Build the current board hash so we can get the minimum firmware
+    // timestamp
+    uint8_t current_board_hash[HASH_LEN] = {0};
+    get_current_board_hash(current_board_hash);
+
+    uint32_t firmware_timestamp = se_get_firmware_timestamp(current_board_hash);
+
+    FirmwareResult result = {0};
+    foundation_firmware_verify_update_header(header_info.buf,
+                                             header_info.len,
+                                             firmware_timestamp,
+                                             &result);
+
+    switch (result.tag) {
+        case FIRMWARE_RESULT_HEADER_OK:
+            tuple[0] = mp_obj_new_str_copy(&mp_type_str,
+                                           (const uint8_t*)result.HEADER_OK.version,
+                                           strlen((const char*)result.HEADER_OK.version));
+            tuple[1] = result.HEADER_OK.signed_by_user ? mp_const_true : mp_const_false;
+            return mp_obj_new_tuple(2, tuple);
+        case FIRMWARE_RESULT_INVALID_HEADER:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Invalid firmware header"));
+        case FIRMWARE_RESULT_UNKNOWN_MAGIC:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Unknown firmware magic bytes"));
+            break;
+        case FIRMWARE_RESULT_INVALID_TIMESTAMP:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Invalid firmware timestamp"));
+            break;
+        case FIRMWARE_RESULT_TOO_SMALL:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware size is too small: %"PRIu32" bytes."),
+                              result.TOO_SMALL.len);
+            break;
+        case FIRMWARE_RESULT_TOO_BIG:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware size is too big: %"PRIu32" bytes."),
+                              result.TOO_BIG.len);
+            break;
+        case FIRMWARE_RESULT_TOO_OLD:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware is older than current, timestamp is: %"PRIu32"."),
+                              result.TOO_OLD.timestamp);
+            break;
+        case FIRMWARE_RESULT_INVALID_PUBLIC_KEY1_INDEX:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Public Key is out of range (%"PRIu32")."),
+                              result.INVALID_PUBLIC_KEY1_INDEX.index);
+            break;
+        case FIRMWARE_RESULT_INVALID_PUBLIC_KEY2_INDEX:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Public Key is out of range (%"PRIu32")."),
+                              result.INVALID_PUBLIC_KEY2_INDEX.index);
+            break;
+        case FIRMWARE_RESULT_SAME_PUBLIC_KEY:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Same Public Key was used for both signatures (%"PRIu32")."),
+                              result.SAME_PUBLIC_KEY.index);
+            break;
+        default:
+            break;
+    }
+
+    mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                 MP_ERROR_TEXT("Unhandled case in firmware verification"));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_passport_verify_update_header_obj,
+                                 mod_passport_verify_update_header);
+
+STATIC mp_obj_t mod_passport_verify_update_signatures(mp_obj_t header, mp_obj_t validation_hash) {
+    uint8_t buf[72];
+    uint8_t public_key[64];
+
+    mp_buffer_info_t header_info;
+    mp_get_buffer_raise(header, &header_info, MP_BUFFER_READ);
+
+    mp_buffer_info_t validation_hash_info;
+    mp_get_buffer_raise(validation_hash, &validation_hash_info, MP_BUFFER_READ);
+
+    // Build the current board hash so we can get the minimum firmware
+    // timestamp
+    uint8_t current_board_hash[HASH_LEN] = {0};
+    get_current_board_hash(current_board_hash);
+
+    uint32_t firmware_timestamp = se_get_firmware_timestamp(current_board_hash);
+
+    se_pair_unlock();
+    bool has_user_key = se_read_data_slot(KEYNUM_user_fw_pubkey, buf, sizeof(buf)) == 0;
+    memcpy(public_key, buf, sizeof(public_key));
+
+    FirmwareResult result = {0};
+    foundation_firmware_verify_update_signatures(header_info.buf,
+                                                 header_info.len,
+                                                 firmware_timestamp,
+                                                 validation_hash_info.buf,
+                                                 has_user_key ? &public_key : NULL,
+                                                 &result);
+
+    // Signature verification also validates the header again, so, we have
+    // to handle the errors again.
+    //
+    // TODO: This should be factored out.
+    switch (result.tag) {
+        case FIRMWARE_RESULT_SIGNATURES_OK:
+            return mp_const_true;
+        case FIRMWARE_RESULT_INVALID_HEADER:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Invalid firmware header"));
+        case FIRMWARE_RESULT_UNKNOWN_MAGIC:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Unknown firmware magic bytes"));
+            break;
+        case FIRMWARE_RESULT_INVALID_TIMESTAMP:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Invalid firmware timestamp"));
+            break;
+        case FIRMWARE_RESULT_TOO_SMALL:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware size is too small: %"PRIu32" bytes."),
+                              result.TOO_SMALL.len);
+            break;
+        case FIRMWARE_RESULT_TOO_BIG:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware size is too big: %"PRIu32" bytes."),
+                              result.TOO_BIG.len);
+            break;
+        case FIRMWARE_RESULT_TOO_OLD:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Firmware is older than current, timestamp is: %"PRIu32"."),
+                              result.TOO_OLD.timestamp);
+            break;
+        case FIRMWARE_RESULT_INVALID_PUBLIC_KEY1_INDEX:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Public Key 1 is out of range (%"PRIu32")."),
+                              result.INVALID_PUBLIC_KEY1_INDEX.index);
+            break;
+        case FIRMWARE_RESULT_INVALID_PUBLIC_KEY2_INDEX:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Public Key 2 is out of range (%"PRIu32")."),
+                              result.INVALID_PUBLIC_KEY2_INDEX.index);
+            break;
+        case FIRMWARE_RESULT_SAME_PUBLIC_KEY:
+            mp_raise_msg_varg(&mp_type_InvalidFirmwareUpdate,
+                              MP_ERROR_TEXT("Same Public Key was used for both signatures (%"PRIu32")."),
+                              result.SAME_PUBLIC_KEY.index);
+            break;
+        case FIRMWARE_RESULT_INVALID_USER_SIGNATURE:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("User signature verification failed"));
+            break;
+        case FIRMWARE_RESULT_FAILED_SIGNATURE1:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("First signature verification failed"));
+        case FIRMWARE_RESULT_FAILED_SIGNATURE2:
+            mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                         MP_ERROR_TEXT("Second signature verification failed"));
+        default:
+            break;
+    }
+
+    mp_raise_msg(&mp_type_InvalidFirmwareUpdate,
+                 MP_ERROR_TEXT("Unhandled case in firmware signatures verification"));
+    return mp_const_false;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_passport_verify_update_signatures_obj,
+                                 mod_passport_verify_update_signatures);
+
 STATIC const mp_rom_map_elem_t passport_module_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_passport)},
+    {MP_ROM_QSTR(MP_QSTR_InvalidFirmwareUpdate), MP_ROM_PTR(&mp_type_InvalidFirmwareUpdate)},
     {MP_ROM_QSTR(MP_QSTR_camera), MP_ROM_PTR(&mod_passport_camera_module)},
     {MP_ROM_QSTR(MP_QSTR_IS_SIMULATOR), MP_ROM_FALSE},
     {MP_ROM_QSTR(MP_QSTR_supply_chain_challenge), MP_ROM_PTR(&mod_passport_supply_chain_challenge_obj)},
     {MP_ROM_QSTR(MP_QSTR_verify_supply_chain_server_signature),
      MP_ROM_PTR(&mod_passport_verify_supply_chain_server_signature_obj)},
+    {MP_ROM_QSTR(MP_QSTR_verify_update_header),
+     MP_ROM_PTR(&mod_passport_verify_update_header_obj)},
+    {MP_ROM_QSTR(MP_QSTR_verify_update_signatures),
+     MP_ROM_PTR(&mod_passport_verify_update_signatures_obj)},
 #ifdef SCREEN_MODE_COLOR
     {MP_ROM_QSTR(MP_QSTR_IS_COLOR), MP_ROM_TRUE},
 #else

--- a/ports/stm32/boards/Passport/modules/constants.py
+++ b/ports/stm32/boards/Passport/modules/constants.py
@@ -33,6 +33,7 @@ SPI_FLASH_TOTAL_SIZE = 8192 * 1024
 FW_MAX_SIZE = (1792 * 1024) - 256
 FW_START = 0
 FW_HEADER_SIZE = 2048
+FW_HEADER_INFORMATION_SIZE = 34  # sizeof(fw_info_t)
 FW_ACTUAL_HEADER_SIZE = 170  # passport_firmware_header_t uses this many bytes
 
 # PSBT signing (uses same memory as firmware updates)

--- a/ports/stm32/boards/Passport/modules/tasks/__init__.py
+++ b/ports/stm32/boards/Passport/modules/tasks/__init__.py
@@ -54,4 +54,5 @@ from .sign_psbt_task import sign_psbt_task
 from .sign_text_file_task import sign_text_file_task
 from .validate_electrum_message_task import validate_electrum_message_task
 from .validate_psbt_task import validate_psbt_task
+from .verify_firmware_signature_task import verify_firmware_signature_task
 from .verify_backup_task import verify_backup_task

--- a/ports/stm32/boards/Passport/modules/tasks/verify_firmware_signature_task.py
+++ b/ports/stm32/boards/Passport/modules/tasks/verify_firmware_signature_task.py
@@ -1,0 +1,72 @@
+# Task to verify the signatures of a firmware update before copying to
+# SPI flash.
+#
+# SPDX-FileCopyrightText: © 2024 Foundation Devices, Inc. <hello@foundationdevices.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import passport
+import trezorcrypto
+import foundation
+from uasyncio import sleep_ms
+from ubinascii import hexlify as b2a_hex
+from constants import FW_HEADER_SIZE, FW_HEADER_INFORMATION_SIZE
+from files import CardSlot, CardMissingError
+from errors import Error
+
+
+async def verify_firmware_signature_task(file_path, size, on_progress, on_done):
+    header = None
+    s = trezorcrypto.sha256()
+
+    try:
+        with CardSlot() as card:
+            with open(file_path, 'rb') as fp:
+                # This is assumed to have been validated before, TOCTOU
+                # attacks are not an issue here since if the information data
+                # changes so does the validation hash making the signature
+                # verification to fail.
+                header = fp.read(FW_HEADER_SIZE)
+                s.update(header[:FW_HEADER_INFORMATION_SIZE])
+
+                buf = bytearray(1024)
+                pos = FW_HEADER_SIZE
+                update_display = 0
+                while pos < size:
+                    # Update every 50 reads.
+                    if update_display % 50 == 0:
+                        percent = int((pos / size) * 100)
+                        on_progress(percent)
+
+                        # Allow UI to update progress.
+                        await sleep_ms(1)
+
+                    here = fp.readinto(buf)
+                    s.update(buf[:here])
+                    pos += here
+
+                    update_display += 1
+    except CardMissingError:
+        await on_done(Error.MICROSD_CARD_MISSING, None)
+        return
+    except Exception as e:
+        error_message = "Firmware update error: {}, Info: {}".format(e.__class__.__name__,
+                                                                     e.args[0] if len(e.args) == 1 else e.args)
+        await on_done(Error.FIRMWARE_UPDATE_FAILED, error_message)
+        return
+
+    single_sha = s.digest()
+    double_sha = bytearray(32)
+    foundation.sha256(single_sha, double_sha)
+
+    try:
+        passport.verify_update_signatures(header, double_sha)
+    except passport.InvalidFirmwareUpdate as e:
+        await on_done(Error.FIRMWARE_UPDATE_FAILED, "Invalid firmware signatures")
+        return
+    except Exception as e:
+        error_message = "Firmware update error: {}, Info: {}".format(e.__class__.__name__,
+                                                                     e.args[0] if len(e.args) == 1 else e.args)
+        await on_done(Error.FIRMWARE_UPDATE_FAILED, error_message)
+        return
+
+    await on_done(None, None)


### PR DESCRIPTION
This does the same as the bootloader but verifies the image before copying it to check if the user has a corrupt firmware image. The bootloader checked this anyway so this is an extra layer of measure.