### PR TITLE
SFT-3854: Enable debug logging when signing firmware.

### DIFF
--- a/ports/stm32/Justfile
+++ b/ports/stm32/Justfile
@@ -98,7 +98,7 @@ sign version="1.0.0" screen="mono" dev="" ext="": (build screen dev ext)
     fi
 
     echo -e "\nAdding user signature...\n"
-    cosign -t {{lowercase(screen)}} -f $COSIGN_FILEPATH -k {{cosign_keypath}} -v {{version}}
+    cosign -d -t {{lowercase(screen)}} -f $COSIGN_FILEPATH -k {{cosign_keypath}} -v {{version}}
 
     # Remove .bin and append the signed filename string
     if [ {{screen}} == "color" ]


### PR DESCRIPTION
No private key material is leaked, only the calculated hash that is then verified by the bootloader is printed.

* ports/stm32/Justfile (sign): Pass -d option to cosign.

See CI output for an example.