### PR TITLE
SFT-4381: Enable debug symbols for the firmware.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,12 @@ jobs:
       env:
         SIGNING_KEY: ${{ secrets.UserSigningKey }}
 
+    - name: Upload firmware ELF
+      uses: actions/upload-artifact@v4
+      with:
+        name: v${{env.version}}${{ matrix.build.suffix }}.elf
+        path: ports/stm32/build-Passport/firmware.elf
+
     - name: Upload firmware (unsigned)
       uses: actions/upload-artifact@v4
       with:

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -151,6 +151,16 @@ else
 COPT += -O2 -DNDEBUG
 endif
 
+# FOUNDATION CHANGE: BEGIN
+#
+# Instead of using DEBUG=1 (which defines -DPENDSV_DEBUG) which is not
+# necessary, just enable debugging information generation directly.
+#
+# This does not affect the final binary size, only the ELF file which
+# should only be used by developers.
+CFLAGS += -g
+# FOUNDATION CHANGE: END
+
 # Flags for optional C++ source code
 CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
 CXXFLAGS += $(CXXFLAGS_MOD)


### PR DESCRIPTION
* .github/workflows/build.yaml: Upload ELF file with debugging information.
* ports/stm32/Makefile (CFLAGS): Add -g flag.