### PR TITLE
SFT-4382: Bump GitHub actions dependency versions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         driver-opts: network=host
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       with:
         push: true
         context: .
@@ -116,7 +116,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         driver-opts: network=host
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       with:
         push: true
         context: .
@@ -163,7 +163,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         driver-opts: network=host
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       with:
         push: true
         context: .
@@ -197,7 +197,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         driver-opts: network=host
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v6
       with:
         push: true
         context: .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: fsfe/reuse-action@v2
+      - uses: fsfe/reuse-action@v4
 
   rust-code-compiles:
     name: Rust code compiles?


### PR DESCRIPTION
Closes #551 and #552.