### PR TITLE
SFT-4385: Don't strip Rust debug information.

### DIFF
--- a/extmod/foundation-rust/Cargo.toml
+++ b/extmod/foundation-rust/Cargo.toml
@@ -86,5 +86,5 @@ crate-type = ["lib", "staticlib"]
 lto = "fat"
 opt-level = "z"
 codegen-units = 1
-strip = true
+strip = "none"
 panic = "abort"


### PR DESCRIPTION
* extmod/foundation-rust/Cargo.toml (profile) <release>: Don't strip debug information.