### PR TITLE
Harden message-signing follow-ups: QR expected_address + microSD size cap

### DIFF
--- a/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
@@ -27,6 +27,12 @@ def is_signable(filename, path=None):
     return True
 
 
+def bounded_message_read(fd):
+    from public_constants import MSG_SIGNING_MAX_LENGTH
+
+    return fd.read(MSG_SIGNING_MAX_LENGTH + 1)
+
+
 class HealthCheckMicrosdFlow(Flow):
     def __init__(self, context=None, normal_signing=False):
         super().__init__(initial_state=self.choose_file, name='HealthCheckMicrosdFlow')
@@ -59,12 +65,7 @@ class HealthCheckMicrosdFlow(Flow):
             from pages import ErrorPage
             from public_constants import MSG_SIGNING_MAX_LENGTH
 
-            cap = MSG_SIGNING_MAX_LENGTH + 1
-
-            def bounded_read(fd):
-                return fd.read(cap)
-
-            raw = await ReadFileFlow(self.file_path, binary=True, read_fn=bounded_read).run()
+            raw = await ReadFileFlow(self.file_path, binary=True, read_fn=bounded_message_read).run()
 
             if not raw:
                 self.set_result(False)

--- a/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
@@ -53,6 +53,29 @@ class HealthCheckMicrosdFlow(Flow):
     async def parse_message(self):
         from flows import ReadFileFlow
 
+        # Cap file size for general message signing. Health-check protocol
+        # files have implicit length constraints and are exempted.
+        if self.normal_signing:
+            import os
+            from files import CardSlot, CardMissingError
+            from pages import ErrorPage
+            from public_constants import MSG_SIGNING_MAX_LENGTH
+
+            try:
+                with CardSlot() as card:
+                    size = os.stat(self.file_path)[6]
+            except CardMissingError:
+                await ErrorPage('microSD card removed.').show()
+                self.set_result(False)
+                return
+
+            if size > MSG_SIGNING_MAX_LENGTH:
+                await ErrorPage(
+                    'Message file is too long. Max length is {} bytes.'.format(MSG_SIGNING_MAX_LENGTH)
+                ).show()
+                self.set_result(False)
+                return
+
         data = await ReadFileFlow(self.file_path, binary=False).run()
 
         if not data:

--- a/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/health_check_microsd_flow.py
@@ -53,34 +53,42 @@ class HealthCheckMicrosdFlow(Flow):
     async def parse_message(self):
         from flows import ReadFileFlow
 
-        # Cap file size for general message signing. Health-check protocol
-        # files have implicit length constraints and are exempted.
+        # Bound the read inside one CardSlot() lifetime; a separate pre-stat
+        # would leave a TOCTOU window if the card/file is swapped mid-flow.
         if self.normal_signing:
-            import os
-            from files import CardSlot, CardMissingError
             from pages import ErrorPage
             from public_constants import MSG_SIGNING_MAX_LENGTH
 
-            try:
-                with CardSlot() as card:
-                    size = os.stat(self.file_path)[6]
-            except CardMissingError:
-                await ErrorPage('microSD card removed.').show()
+            cap = MSG_SIGNING_MAX_LENGTH + 1
+
+            def bounded_read(fd):
+                return fd.read(cap)
+
+            raw = await ReadFileFlow(self.file_path, binary=True, read_fn=bounded_read).run()
+
+            if not raw:
                 self.set_result(False)
                 return
 
-            if size > MSG_SIGNING_MAX_LENGTH:
+            if len(raw) > MSG_SIGNING_MAX_LENGTH:
                 await ErrorPage(
                     'Message file is too long. Max length is {} bytes.'.format(MSG_SIGNING_MAX_LENGTH)
                 ).show()
                 self.set_result(False)
                 return
 
-        data = await ReadFileFlow(self.file_path, binary=False).run()
+            try:
+                data = raw.decode('utf-8')
+            except (UnicodeError, AttributeError):
+                await ErrorPage('Message file contains invalid text.').show()
+                self.set_result(False)
+                return
+        else:
+            data = await ReadFileFlow(self.file_path, binary=False).run()
 
-        if not data:
-            self.set_result(False)
-            return
+            if not data:
+                self.set_result(False)
+                return
 
         self.lines = data.split('\n')
         self.goto(self.common_flow)

--- a/ports/stm32/boards/Passport/modules/flows/sign_electrum_message_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/sign_electrum_message_flow.py
@@ -59,7 +59,7 @@ class SignElectrumMessageFlow(Flow):
             node = sv.derive_path(self.subpath)
             self.address = sv.chain.address(node, self.addr_format)
 
-        self.address = stylize_address(self.address)
+        display_address = stylize_address(self.address)
 
         result = await LongTextPage(centered=True,
                                     text=('\n' + self.message),
@@ -69,7 +69,7 @@ class SignElectrumMessageFlow(Flow):
             self.set_result(False)
             return
 
-        result = await LongQuestionPage(text='Sign message with this address?\n\n{}'.format(self.address),
+        result = await LongQuestionPage(text='Sign message with this address?\n\n{}'.format(display_address),
                                         right_micron=microns.Sign,
                                         margins=MARGIN_FOR_ADDRESSES,
                                         top_margin=8).show()
@@ -82,7 +82,7 @@ class SignElectrumMessageFlow(Flow):
 
     async def do_sign(self):
         (sig, address, error) = await spinner_task('Signing message', sign_text_file_task,
-                                                   args=[self.message, self.subpath, self.addr_format])
+                                                   args=[self.message, self.subpath, self.addr_format, self.address])
         if error is None:
             self.signature = sig
             self.goto(self.show_signed)


### PR DESCRIPTION
Follow-up to #636. Two non-blocking nits surfaced during second-opinion review of that PR.

## Changes

### 1. Pass `expected_address` through the QR message-signing path

`SignElectrumMessageFlow.do_sign` now passes the previewed address as `expected_address` to `sign_text_file_task`, matching what `HealthCheckCommonFlow` already does on the microSD path. The task's defensive TOCTOU assertion now protects QR signing too.

Required side-fix: `self.address` was being overwritten with the stylized display form (`self.address = stylize_address(self.address)`), which would have caused the assertion to always fail (raw vs. stylized). Stylization is now stored in a local `display_address`; `self.address` stays raw.

### 2. Enforce `MSG_SIGNING_MAX_LENGTH` on the microSD message-signing path

`HealthCheckMicrosdFlow.parse_message` now rejects files larger than `MSG_SIGNING_MAX_LENGTH` (240 bytes) when `normal_signing=True`. The deleted `SignTextFileFlow` used to enforce this; the protection went missing when the menu entry was consolidated into `HealthCheckMicrosdFlow` in #636. Health-check files are exempted (they have their own format constraints).

The size is checked via `os.stat` inside a `CardSlot()` context, before `ReadFileFlow` is invoked, so an oversized file never gets fully read into RAM.
