### PR TITLE
Update Pillow constraints for host tooling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,9 +102,9 @@ Passport comes with a set of `Justfile` command scripts.  Using these commands r
     
     cargo install just 
     
-Note that Python `Pillow` must be updated to `8.4.0` for all commands to work properly using the following command:
+Note that Python `Pillow` must be at least `12.3.0` for all commands to work properly using the following command:
 
-    pip install Pillow==8.4.0
+    pip install 'Pillow>=12.3.0'
 
 `ports/stm32/Justfile` contains all the `just` commands you can run to build firmware for Passport. You'll typically want to be in the `ports/stm32` folder to run these commands.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,9 +102,9 @@ Passport comes with a set of `Justfile` command scripts.  Using these commands r
     
     cargo install just 
     
-Note that Python `Pillow` must be at least `12.3.0` for all commands to work properly using the following command:
+The image tooling requires Python 3.10 or newer and `Pillow` 12.3.x:
 
-    pip install 'Pillow>=12.3.0'
+    pip install 'Pillow>=12.3.0,<13'
 
 `ports/stm32/Justfile` contains all the `just` commands you can run to build firmware for Passport. You'll typically want to be in the `ports/stm32` folder to run these commands.
 

--- a/extmod/trezor-firmware/pyproject.toml
+++ b/extmod/trezor-firmware/pyproject.toml
@@ -55,7 +55,7 @@ click = "^7"
 ed25519 = "^1.4"
 requests = "^2.19"
 termcolor = "*"
-Pillow = "^12.3.0"
+Pillow = { version = "^12.3.0", python = ">=3.10" }
 
 # crypto
 ecdsa = "^0.16"

--- a/extmod/trezor-firmware/pyproject.toml
+++ b/extmod/trezor-firmware/pyproject.toml
@@ -55,7 +55,7 @@ click = "^7"
 ed25519 = "^1.4"
 requests = "^2.19"
 termcolor = "*"
-Pillow = "^8.0"
+Pillow = "^12.3.0"
 
 # crypto
 ecdsa = "^0.16"

--- a/extmod/trezor-firmware/python/requirements-optional.txt
+++ b/extmod/trezor-firmware/python/requirements-optional.txt
@@ -1,6 +1,6 @@
 hidapi >= 0.7.99.post20
 rlp >= 1.1.0
 web3 >= 4.8
-Pillow
+Pillow>=12.3.0,<13; python_version>='3.10'
 stellar-sdk>=4.0.0,<6.0.0
 types-click

--- a/extmod/trezor-firmware/python/setup.py
+++ b/extmod/trezor-firmware/python/setup.py
@@ -37,7 +37,7 @@ extras_require = {
     "hidapi": ["hidapi>=0.7.99.post20"],
     "ethereum": ["rlp>=1.1.0", "web3>=4.8"],
     "qt-widgets": ["PyQt5"],
-    "extra": ["Pillow"],
+    "extra": ["Pillow>=12.3.0"],
     "stellar": ["stellar-sdk>=4.0.0,<6.0.0"],
 }
 

--- a/extmod/trezor-firmware/python/setup.py
+++ b/extmod/trezor-firmware/python/setup.py
@@ -37,7 +37,7 @@ extras_require = {
     "hidapi": ["hidapi>=0.7.99.post20"],
     "ethereum": ["rlp>=1.1.0", "web3>=4.8"],
     "qt-widgets": ["PyQt5"],
-    "extra": ["Pillow>=12.3.0"],
+    "extra": ["Pillow>=12.3.0,<13; python_version>='3.10'"],
     "stellar": ["stellar-sdk>=4.0.0,<6.0.0"],
 }
 

--- a/extmod/trezor-firmware/python/tox.ini
+++ b/extmod/trezor-firmware/python/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py37,
     py38,
     py39,
+    py310,
 
 [testenv]
 deps =


### PR DESCRIPTION
## Summary

- require patched Pillow 12.3.x for the vendored Trezor image tooling
- apply the dependency only on Python 3.10+, matching Pillow's supported interpreter range
- align the trezorlib `extra` dependency and developer setup instructions

## Context

These dependency alerts are for host-side Python tooling in the vendored Trezor tree. Passport firmware does not ship CPython or Pillow, so this is dependency hygiene for developer/build environments rather than a device-runtime fix.

## Validation

- parsed the Poetry dependency metadata
- validated the PEP 508 requirement and Python marker
- ran a Pillow 12.3 image resize/pixel-access smoke test on a repository asset