### PR TITLE
Harden firmware update validation

### DIFF
--- a/ports/stm32/boards/Passport/bootloader/update.c
+++ b/ports/stm32/boards/Passport/bootloader/update.c
@@ -338,6 +338,9 @@ void update_firmware(void) {
         }
     }
 
+    bool is_spi_fw_user_signed     = spihdr.signature.pubkey1 == FW_USER_KEY;
+    bool is_current_firmware_valid = false;
+
     // Handle the firmware hash update
     get_current_board_hash(current_board_hash);
 
@@ -353,12 +356,11 @@ void update_firmware(void) {
 #ifdef DEBUG_PRINT_UPDATE_HASH
     printf("Verifying current firmware before update\r\n");
 #endif
-    if (verify_current_firmware(true) == SEC_TRUE) {
+    is_current_firmware_valid = verify_current_firmware(true) == SEC_TRUE;
+    if (is_current_firmware_valid) {
 #ifdef DEBUG_PRINT_UPDATE_HASH
         printf("  Current firmware is valid, so doing more checks.\r\n");
 #endif
-
-        bool is_spi_fw_user_signed = spihdr.signature.pubkey1 == FW_USER_KEY;
 
 #ifdef PRODUCTION_BUILD
         uint32_t current_firmware_timestamp = se_get_firmware_timestamp(current_board_hash);
@@ -393,29 +395,36 @@ void update_firmware(void) {
             }
         }
 #endif
-
-        calculate_spi_hash(&spihdr, spi_fw_hash, sizeof(spi_fw_hash));
+    }
 #ifdef DEBUG_PRINT_UPDATE_HASH
-        printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n");
-        bytes_to_hex_str((void*)&spihdr, sizeof(spihdr), str_buf, 64, "\r\n");
-        printf("spihdr\r\n%s\r\n", str_buf);
-        bytes_to_hex_str((void*)spi_fw_hash, sizeof(spi_fw_hash), str_buf, 64, "\r\n");
-        printf("spi_fw_hash\r\n%s\r\n", str_buf);
-        printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n");
+    else {
+        printf("  Current firmware is INVALID - fall through to try the update.\r\n");
+    }
 #endif
-        // Verify the signature and bail if it fails
-        if (verify_signature(&spihdr, spi_fw_hash, sizeof(spi_fw_hash)) == SEC_FALSE) {
-        error4:
-            if (ui_show_error("PASSPORT", "Update Error",
-                              "The firmware update is not properly signed and will not be installed.", &ICON_SHUTDOWN,
-                              &ICON_CHECKMARK, true) == KEY_RIGHT_SELECT) {
-                goto out;
-            } else {
-                ui_ask_shutdown();
-                goto error4;
-            }
-        }
 
+    calculate_spi_hash(&spihdr, spi_fw_hash, sizeof(spi_fw_hash));
+#ifdef DEBUG_PRINT_UPDATE_HASH
+    printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n");
+    bytes_to_hex_str((void*)&spihdr, sizeof(spihdr), str_buf, 64, "\r\n");
+    printf("spihdr\r\n%s\r\n", str_buf);
+    bytes_to_hex_str((void*)spi_fw_hash, sizeof(spi_fw_hash), str_buf, 64, "\r\n");
+    printf("spi_fw_hash\r\n%s\r\n", str_buf);
+    printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\r\n");
+#endif
+    // Verify the incoming firmware signature before attempting to install it.
+    if (verify_signature(&spihdr, spi_fw_hash, sizeof(spi_fw_hash)) == SEC_FALSE) {
+    error4:
+        if (ui_show_error("PASSPORT", "Update Error",
+                          "The firmware update is not properly signed and will not be installed.", &ICON_SHUTDOWN,
+                          &ICON_CHECKMARK, true) == KEY_RIGHT_SELECT) {
+            goto out;
+        } else {
+            ui_ask_shutdown();
+            goto error4;
+        }
+    }
+
+    if (is_current_firmware_valid) {
         /*
          * Calculate a new board hash based on the SPI firmware and then
          * reprogram the board hash in the SE. If the update fails it
@@ -456,11 +465,6 @@ void update_firmware(void) {
             }
         }
     }
-#ifdef DEBUG_PRINT_UPDATE_HASH
-    else {
-        printf("  Current firmware is INVALID - fall through to try the update.\r\n");
-    }
-#endif
 
     rc = do_update(FW_HEADER_SIZE + spihdr.info.fwlength);
     if (rc < 0) {

--- a/ports/stm32/boards/Passport/bootloader/update.c
+++ b/ports/stm32/boards/Passport/bootloader/update.c
@@ -338,8 +338,8 @@ void update_firmware(void) {
         }
     }
 
-    bool is_spi_fw_user_signed     = spihdr.signature.pubkey1 == FW_USER_KEY;
-    bool is_current_firmware_valid = false;
+    bool      is_spi_fw_user_signed = spihdr.signature.pubkey1 == FW_USER_KEY;
+    secresult current_firmware_result;
 
     // Handle the firmware hash update
     get_current_board_hash(current_board_hash);
@@ -356,8 +356,8 @@ void update_firmware(void) {
 #ifdef DEBUG_PRINT_UPDATE_HASH
     printf("Verifying current firmware before update\r\n");
 #endif
-    is_current_firmware_valid = verify_current_firmware(true) == SEC_TRUE;
-    if (is_current_firmware_valid) {
+    current_firmware_result = verify_current_firmware(true);
+    if (current_firmware_result == SEC_TRUE) {
 #ifdef DEBUG_PRINT_UPDATE_HASH
         printf("  Current firmware is valid, so doing more checks.\r\n");
 #endif
@@ -424,7 +424,7 @@ void update_firmware(void) {
         }
     }
 
-    if (is_current_firmware_valid) {
+    if (current_firmware_result == SEC_TRUE) {
         /*
          * Calculate a new board hash based on the SPI firmware and then
          * reprogram the board hash in the SE. If the update fails it


### PR DESCRIPTION
## Summary
- verify the staged firmware image signature before the update copy path can run
- keep downgrade, timestamp, and Secure Element board-hash updates gated on the current firmware being valid
- preserve the existing recovery path for replacing an invalid current firmware with a signed update
- retain the fault-resistant `secresult` value when reusing current-firmware validity

## Validation
- `git diff --check`
- GitHub Actions bootloader builds for light and dark variants
- GitHub Actions firmware, simulator, tools, Python, Rust, and REUSE checks