### PR TITLE
Show amounts for OP_RETURN outputs

### DIFF
--- a/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
@@ -16,7 +16,7 @@ from pages.chooser_page import ChooserPage
 from styles.colors import HIGHLIGHT_TEXT_HEX, BLACK_HEX
 from tasks import sign_psbt_task, validate_psbt_task
 import gc
-from utils import spinner_task, recolor, stylize_address
+from utils import escape_text, spinner_task, recolor, stylize_address
 
 
 class SignPsbtCommonFlow(Flow):
@@ -205,7 +205,7 @@ class SignPsbtCommonFlow(Flow):
                 recolor(HIGHLIGHT_TEXT_HEX, 'Amount'),
                 val,
                 recolor(HIGHLIGHT_TEXT_HEX, 'Message'),
-                dest.split('\n', 1)[1])  # user-defined message starts after "OP_RETURN:\n"
+                escape_text(dest.split('\n', 1)[1]))  # user-defined message starts after "OP_RETURN:\n"
 
         dest = stylize_address(dest)
 

--- a/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
@@ -201,7 +201,9 @@ class SignPsbtCommonFlow(Flow):
         dest = self.chain.render_address(o.scriptPubKey)
 
         if dest.startswith("OP_RETURN"):
-            return '\n{}\n{}'.format(
+            return '\n{}\n{}\n\n{}\n{}'.format(
+                recolor(HIGHLIGHT_TEXT_HEX, 'Amount'),
+                val,
                 recolor(HIGHLIGHT_TEXT_HEX, 'Message'),
                 dest.split('\n', 1)[1])  # user-defined message starts after "OP_RETURN:\n"
 

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -24,5 +24,9 @@ def test_ui(test):
     assert test('ui.py') == b'OK'
 
 
+def test_sign_psbt(test):
+    assert test('sign_psbt.py') == b'OK'
+
+
 def test_foundation(test):
     assert test('foundation.py') == b'OK'

--- a/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
@@ -1,9 +1,11 @@
-# SPDX-FileCopyrightText: 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Test trusted-display rendering for PSBT outputs.
 
 from flows.sign_psbt_common_flow import SignPsbtCommonFlow
+from styles.colors import HIGHLIGHT_TEXT_HEX
+from utils import escape_text, recolor, stylize_address
 
 
 class FakeChain:
@@ -16,6 +18,15 @@ class FakeChain:
 
 class FakeFlow:
     chain = FakeChain()
+
+
+class FakeAddressChain(FakeChain):
+    def render_address(self, script):
+        return script
+
+
+class FakeAddressFlow:
+    chain = FakeAddressChain()
 
 
 class FakeOutput:
@@ -39,10 +50,21 @@ def assert_op_return_output(value, message):
 assert_op_return_output(0, 'zero-value-message')
 assert_op_return_output(50000000, 'payment-id-12345')
 
-malicious_message = '#00bdcd Amount#\n0.00000001 BTC\n\n#00bdcd Destination#\nbc1qattacker'
+amount_heading = recolor(HIGHLIGHT_TEXT_HEX, 'Amount')
+message_heading = recolor(HIGHLIGHT_TEXT_HEX, 'Message')
+destination_heading = recolor(HIGHLIGHT_TEXT_HEX, 'Destination')
+malicious_message = '{}\n0.00000001 BTC\n\n{}\nbc1qattacker'.format(
+    amount_heading, destination_heading)
 rendered = SignPsbtCommonFlow.render_output(FakeFlow(), FakeOutput(1, malicious_message))
-assert rendered == (
-    '\n#00bdcd Amount#\n1 sats\n\n#00bdcd Message#\n'
-    '##00bdcd Amount##\n0.00000001 BTC\n\n##00bdcd Destination##\nbc1qattacker')
+assert escape_text(malicious_message) in rendered
+assert rendered.count('\n{}\n'.format(amount_heading)) == 1
+assert rendered.count('\n{}\n'.format(message_heading)) == 1
+assert rendered.count('\n{}\n'.format(destination_heading)) == 0
+assert malicious_message not in rendered
+
+address = 'bc1qvaliddestination'
+rendered = SignPsbtCommonFlow.render_output(FakeAddressFlow(), FakeOutput(42, address))
+assert rendered == '\n{}\n42 sats\n\n{}\n{}'.format(
+    amount_heading, destination_heading, stylize_address(address))
 
 return_value.write(b'OK')

--- a/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
@@ -39,4 +39,10 @@ def assert_op_return_output(value, message):
 assert_op_return_output(0, 'zero-value-message')
 assert_op_return_output(50000000, 'payment-id-12345')
 
+malicious_message = '#00bdcd Amount#\n0.00000001 BTC\n\n#00bdcd Destination#\nbc1qattacker'
+rendered = SignPsbtCommonFlow.render_output(FakeFlow(), FakeOutput(1, malicious_message))
+assert rendered == (
+    '\n#00bdcd Amount#\n1 sats\n\n#00bdcd Message#\n'
+    '##00bdcd Amount##\n0.00000001 BTC\n\n##00bdcd Destination##\nbc1qattacker')
+
 return_value.write(b'OK')

--- a/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/sign_psbt.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Test trusted-display rendering for PSBT outputs.
+
+from flows.sign_psbt_common_flow import SignPsbtCommonFlow
+
+
+class FakeChain:
+    def render_value(self, value):
+        return (str(value), 'sats')
+
+    def render_address(self, script):
+        return 'OP_RETURN:\n{}'.format(script)
+
+
+class FakeFlow:
+    chain = FakeChain()
+
+
+class FakeOutput:
+    def __init__(self, value, message):
+        self.nValue = value
+        self.scriptPubKey = message
+
+
+def assert_op_return_output(value, message):
+    rendered = SignPsbtCommonFlow.render_output(FakeFlow(), FakeOutput(value, message))
+
+    amount_label = rendered.find('Amount')
+    amount = rendered.find('{} sats'.format(value))
+    message_label = rendered.find('Message')
+    payload = rendered.find(message)
+
+    assert -1 not in (amount_label, amount, message_label, payload)
+    assert amount_label < amount < message_label < payload
+
+
+assert_op_return_output(0, 'zero-value-message')
+assert_op_return_output(50000000, 'payment-id-12345')
+
+return_value.write(b'OK')


### PR DESCRIPTION
## Summary

- show the formatted output amount alongside every OP_RETURN message during transaction review
- render user-controlled OP_RETURN text literally by escaping LVGL recolor delimiters
- add simulator regression coverage for zero-value, nonzero-value, forged-markup, and normal address outputs

## Root cause

`render_output()` calculated the output value before classifying the destination, but its OP_RETURN branch returned early without including that value in the trusted-display text. The same branch inserted the decoded OP_RETURN message into a recolor-enabled label without escaping `#` delimiters, allowing message text to be interpreted as highlighted UI markup.

## Impact

Users can review the full economic value of an OP_RETURN output before signing. OP_RETURN messages can no longer create highlighted text that resembles trusted Amount or Destination rows. These changes affect display formatting only; PSBT parsing, fee calculation, and signing behavior are unchanged.

## Validation

- palette-independent renderer regression script exercised with color and monochrome highlight values
- `python -m pycodestyle` for the changed Python files
- `git diff --check`