### PR TITLE
noise: ensure every requested source covers the whole buffer

### DIFF
--- a/ports/stm32/boards/Passport/noise.c
+++ b/ports/stm32/boards/Passport/noise.c
@@ -67,6 +67,9 @@ bool noise_get_random_bytes(uint8_t sources, void* buf, size_t buf_len) {
 
     // Buffer must be at least 4 bytes - if less is needed, caller can extract 1-3 bytes from a 4-byte buffer.
     if (buf_len < 4) {
+#ifndef FACTORY_TEST
+        frequency_turbo(false);
+#endif
         return false;
     }
 
@@ -107,26 +110,32 @@ bool noise_get_random_bytes(uint8_t sources, void* buf, size_t buf_len) {
     // MCU RNG
     if (sources & NOISE_MCU_RNG_SOURCE) {
         // printf("Using MCU source\n");
-        uint32_t* pbuf32 = (uint32_t*)buf;
+        uint8_t* pbuf8 = (uint8_t*)buf;
+        size_t   pos   = 0;
 
-        // NOTE: We don't sample and mixin additional entropy into the final 1-3 bytes if buffer size
-        //       is not a multiple of 4 bytes.
-        for (int i = 0; i < buf_len / 4; i++) {
+        // Mix in a fresh sample over the whole buffer, including a trailing
+        // partial word when buf_len is not a multiple of 4 bytes.
+        while (pos < buf_len) {
             uint32_t sample = rng_sample();
+            size_t   n      = MIN(buf_len - pos, sizeof(sample));
             // printf("MCU SAMPLE: 0x%08lx\n", sample);
             // XOR in the sample
-            *(pbuf32 + i) ^= sample;
+            xor_mixin(pbuf8 + pos, (uint8_t*)&sample, (int)n);
+            pos += n;
         }
     }
 
     // Secure Element RNG
     if (sources & NOISE_SE_RNG_SOURCE) {
-        uint8_t* pbuf8     = (uint8_t*)buf;
-        uint8_t* pbuf8_end = pbuf8 + buf_len;
+        uint8_t* pbuf8 = (uint8_t*)buf;
         uint8_t  num_in[20], sample[32];
-        memset(num_in, 0, 20);
+        size_t   pos = 0;
+        memset(num_in, 0, sizeof(num_in));
 
-        for (int i = 0; i < buf_len / 32; i++) {
+        // Mix in SE nonces over the whole buffer. Previously this loop ran
+        // buf_len / 32 times, so buffers shorter than 32 bytes received no SE
+        // entropy at all while the function still reported success.
+        while (pos < buf_len) {
             int rc = se_pick_nonce(num_in, sample);
             if (rc < 0) {
                 se_show_error();
@@ -140,8 +149,9 @@ bool noise_get_random_bytes(uint8_t sources, void* buf, size_t buf_len) {
             // printf("SE SAMPLE: 0x%08lx %08lx %08lx %08lx\n", *s, *(s+1), *(s+2), *(s+3));
 
             // Mixin the sample values - don't overflow output buffer
-            xor_mixin(pbuf8, sample, MIN(pbuf8_end - pbuf8, 32));
-            pbuf8 += 32;
+            size_t n = MIN(buf_len - pos, sizeof(sample));
+            xor_mixin(pbuf8 + pos, sample, (int)n);
+            pos += n;
         }
     }
 


### PR DESCRIPTION
## Summary

`noise_get_random_bytes()` could return `true` while leaving part of the output buffer untouched by one of the requested entropy sources.

| Source | `buf_len` | Behaviour before |
| --- | --- | --- |
| `NOISE_MCU_RNG_SOURCE` | not a multiple of 4 | trailing 1-3 bytes never mixed |
| `NOISE_SE_RNG_SOURCE` | < 32 | no SE entropy mixed at all |
| any | < 4 | returns `false` but leaves `frequency_turbo()` enabled |

The MCU loop ran `buf_len / 4` times and the SE loop `buf_len / 32` times, so a short or unaligned buffer silently fell through. `random_buffer()` in the trezor-crypto glue takes an arbitrary `len` and routes to the MCU-only path, so the unaligned case is reachable by construction even though no current caller hits it.

## Scope

**Seed generation is not affected, and this is not a fix for a reachable weakness.** `new_seed_task` calls `Noise.ALL` with a 32-byte buffer: the avalanche source already fills the whole buffer first, and at 32 bytes both the MCU and SE contributions were already complete. Every current call site uses a length that is a multiple of 4 with either `MCU` or `ALL`. This is defensive hardening of the helper so the failure mode cannot appear as call sites change.

## Change

Both loops now advance by the number of bytes actually mixed (`MIN(buf_len - pos, sizeof(sample))`), so any requested source covers the full buffer for any length >= 4. The MCU path switches to the existing `xor_mixin()` helper for consistency with the SE path. The short-buffer early return now restores the clock before returning.

One file, +21/-11, no behaviour change for any existing caller.

## Testing

The patched function was extracted into a host harness with instrumented `xor_mixin()`/`rng_sample()`/`se_pick_nonce()` stubs that record which bytes are actually written. Every buffer length from 4 to 64 is fully covered for `MCU`, `SE` and `ALL`; the same harness reproduces the gaps on the unpatched version. Builds clean under `-Wall -Wextra`.

I do not have Passport hardware, so this has not been run on-device — the change is confined to buffer arithmetic and touches no ADC, SE or clock configuration.

## Not included here, but worth raising

1. **No runtime health check on the avalanche source.** The bias/bucket test in `bootloader/factory-test.c` only runs at provisioning. If the analog front-end degrades in the field the ADC returns near-constant values and nothing detects it; the MCU and SE XOR still carry the seed, but the headline property is silently lost. Adding this needs a policy decision (warn vs. block seed generation), so it seemed wrong to bundle into this PR.
2. **ADC oversampling on the noise channels.** `adc.c` configures ADC2 with `Oversampling.Ratio = 32x` and `RightBitShift = 5`, i.e. hardware averaging, which attenuates exactly the high-frequency noise the avalanche circuit produces. This may well be deliberate and calibrated against the analog front-end — I have no hardware to measure the actual noise amplitude, so I am asking rather than proposing a change. Is the entropy budget characterised with oversampling enabled?

Happy to split, reword or drop any part of this.