### PR TITLE
Validate legacy settings before flash writes

### DIFF
--- a/ports/stm32/boards/Passport/modules/settings.py
+++ b/ports/stm32/boards/Passport/modules/settings.py
@@ -316,6 +316,11 @@ class Settings:
         # Render as JSON, encrypt and write it
         self.curr_dict['_revision'] = self.curr_dict.get('_revision', 0) + 1
 
+        # Validate the encoded size before selecting or erasing a flash slot.
+        json_buf = ujson.dumps(self.curr_dict).encode('utf8')
+        if len(json_buf) > DATA_SIZE:
+            raise ValueError('JSON data is larger than {} bytes.'.format(DATA_SIZE))
+
         addr = self.next_addr()
 
         # print('===============================================================')
@@ -327,17 +332,6 @@ class Settings:
         aes = self.get_aes(flash_offset)
 
         chk = trezorcrypto.sha256()
-
-        # Create the JSON string as bytes
-        json_buf = ujson.dumps(self.curr_dict).encode('utf8')
-
-        # Ensure data is not too big
-        if len(json_buf) > DATA_SIZE:
-            # print('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
-            # print(' JSON TOO BIG!')
-            # print('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
-            assert false, 'JSON data is larger than {}.'.format(DATA_SIZE)
-            return
 
         # Create a zero-filled byte buf
         padded_buf = bytearray(DATA_SIZE)

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -28,6 +28,10 @@ def test_seedqr_codec(test):
     assert test('seedqr_codec.py') == b'OK'
 
 
+def test_settings(test):
+    assert test('settings.py') == b'OK'
+
+
 def test_ui(test):
     assert test('ui.py') == b'OK'
 

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -20,6 +20,10 @@ def test_ext_settings(test):
     assert test('ext_settings.py') == b'OK'
 
 
+def test_settings(test):
+    assert test('settings.py') == b'OK'
+
+
 def test_ui(test):
     assert test('ui.py') == b'OK'
 

--- a/ports/stm32/boards/Passport/modules/tests/unit/settings.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/settings.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from settings import DATA_SIZE, Settings
+
+
+class OversizedSettings:
+    def __init__(self):
+        self.curr_dict = {'value': 'x' * DATA_SIZE}
+
+    def next_addr(self):
+        raise RuntimeError('Oversized settings reached flash slot selection')
+
+
+settings = OversizedSettings()
+
+try:
+    Settings.save(settings)
+except ValueError as exc:
+    assert str(DATA_SIZE) in str(exc)
+else:
+    raise RuntimeError('Oversized settings should fail before selecting a flash slot')
+
+return_value.write(b'OK')


### PR DESCRIPTION
## Summary

- validate serialized legacy settings size before selecting or erasing a flash slot
- replace the invalid lowercase `assert false` with an explicit `ValueError`
- add a regression test covering oversized settings and the no-flash-selection invariant

## Background

The legacy internal-flash settings backend attempted to reject JSON larger than its 8,160-byte data area with `assert false`. Because Python boolean literals are capitalized, that path raised `NameError`. It also selected a flash slot before checking the serialized size, allowing an oversized save attempt to perform flash management before failing.

This backend is retained for the Passport Founders Edition v1-to-v2 settings migration; current user settings use the external settings backend.

## Validation

- focused overflow-path test with MicroPython modules stubbed
- Python syntax compilation
- `pycodestyle` on the changed Python files
- `git diff --check`