### PR TITLE
Reject malformed SeedQR payloads

### DIFF
--- a/ports/stm32/boards/Passport/modules/data_codecs/seedqr_codec.py
+++ b/ports/stm32/boards/Passport/modules/data_codecs/seedqr_codec.py
@@ -13,7 +13,7 @@ from .data_encoder import DataEncoder
 from .data_decoder import DataDecoder
 from .data_sampler import DataSampler
 from .qr_type import QRType
-from public_constants import SEED_LENGTHS
+from public_constants import SEED_LENGTHS, SEED_WORD_LIST_LENGTH
 
 
 class SeedQRDecoder(DataDecoder):
@@ -33,16 +33,28 @@ class SeedQRDecoder(DataDecoder):
         import trezorcrypto
 
         try:
+            if len(self.data) % 4 != 0:
+                return None
+
+            num_words = len(self.data) // 4
+            if num_words not in SEED_LENGTHS:
+                return None
+
+            if any(c < '0' or c > '9' for c in self.data):
+                return None
+
             seed_phrase = []
-            num_words = int(len(self.data) / 4)
             for i in range(0, num_words):
                 index = int(self.data[i * 4: (i * 4) + 4])
+                if index >= SEED_WORD_LIST_LENGTH:
+                    return None
+
                 word = trezorcrypto.bip39.get_word(index)
+                if word is None:
+                    return None
+
                 seed_phrase.append(word)
-            if len(seed_phrase) in SEED_LENGTHS:
-                return seed_phrase
-            else:
-                return None
+            return seed_phrase
         except Exception as e:
             return None
 

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -24,6 +24,10 @@ def test_psbt_multisig_approval(test):
     assert test('psbt_multisig_approval.py') == b'OK'
 
 
+def test_seedqr_codec(test):
+    assert test('seedqr_codec.py') == b'OK'
+
+
 def test_ui(test):
     assert test('ui.py') == b'OK'
 

--- a/ports/stm32/boards/Passport/modules/tests/unit/seedqr_codec.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/seedqr_codec.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,11 +18,14 @@ assert decode(valid_12) == ['abandon'] * 12
 assert decode(valid_24) == ['zoo'] * 24
 
 malformed = (
+    '',
+    '0000' * 13,
     '2048' + ('0000' * 11),
     '9999' + ('0000' * 11),
     'abcd' + ('0000' * 11),
     '-001' + ('0000' * 11),
     ' 001' + ('0000' * 11),
+    '\u0660' * 4 + ('0000' * 11),
     valid_12 + '0',
     valid_12 + '000',
     valid_24 + '0',

--- a/ports/stm32/boards/Passport/modules/tests/unit/seedqr_codec.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/seedqr_codec.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from data_codecs.seedqr_codec import SeedQRDecoder
+
+
+def decode(data):
+    decoder = SeedQRDecoder()
+    decoder.add_data(data)
+    return decoder.decode()
+
+
+valid_12 = '0000' * 12
+valid_24 = '2047' * 24
+
+assert decode(valid_12) == ['abandon'] * 12
+assert decode(valid_24) == ['zoo'] * 24
+
+malformed = (
+    '2048' + ('0000' * 11),
+    '9999' + ('0000' * 11),
+    'abcd' + ('0000' * 11),
+    '-001' + ('0000' * 11),
+    ' 001' + ('0000' * 11),
+    valid_12 + '0',
+    valid_12 + '000',
+    valid_24 + '0',
+)
+
+for data in malformed:
+    assert decode(data) is None
+
+return_value.write(b'OK')


### PR DESCRIPTION
## Summary

- require SeedQR payloads to contain exactly four ASCII digits per supported seed word
- reject indexes outside the BIP39 word list before calling `get_word()`
- reject a defensive `None` result from the BIP39 binding
- add unit coverage for valid boundaries and malformed payloads

## Background

The SeedQR decoder previously derived the word count by truncating `len(data) / 4` and accepted the decoded list based only on that count. The BIP39 binding returns `None` for an out-of-range index, so a correctly sized QR containing a group such as `9999` could pass decoding with `None` in the word list and later trigger a fatal error in the seed restoration flow.

The same parsing structure also ignored one to three trailing characters and allowed noncanonical groups that `int()` accepted, including whitespace-prefixed values.