### PR TITLE
Avoid displaying unverified PSBT fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 ## Head
+- Identify network fees from unverifiable PSBT inputs as unverified
 - Validate the complete local xpub when importing multisig wallets
 - Require confirmation before using PSBT-proposed multisig wallets with temporary seeds,
   and cancel signing if import is declined

--- a/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
+++ b/ports/stm32/boards/Passport/modules/flows/sign_psbt_common_flow.py
@@ -260,7 +260,9 @@ class SignPsbtCommonFlow(Flow):
             # gc.collect()
 
             fee = self.psbt.calculate_fee()
-            if fee is not None:
+            if not self.psbt.fee_is_verified:
+                msg.write('\n{}\nUnverified '.format(recolor(HIGHLIGHT_TEXT_HEX, 'Network Fee')))
+            elif fee is not None:
                 amount, units = self.chain.render_value(fee)
                 msg.write('\n{}\n{} {} '.format(recolor(HIGHLIGHT_TEXT_HEX, 'Network Fee'), amount, units))
 

--- a/ports/stm32/boards/Passport/modules/psbt.py
+++ b/ports/stm32/boards/Passport/modules/psbt.py
@@ -863,7 +863,7 @@ class psbtInputProxy(psbtProxy):
             # that Passport owns one of the public keys required by the script.
             for which_key in self.required_key:
                 skp = keypath_to_str(self.subpaths[which_key])
-                node = sv.derive_path(skp, register=False)
+                node = sv.derive_path(skp, register=True)
                 if node.public_key() == which_key:
                     return node, which_key
 
@@ -875,13 +875,13 @@ class psbtInputProxy(psbtProxy):
                 (self.subpaths[which_key][0] == my_xfp or
                  self.subpaths[which_key][0] == swab32(my_xfp)):
             skp = keypath_to_str(self.subpaths[which_key])
-            node = sv.derive_path(skp, register=False)
+            node = sv.derive_path(skp, register=True)
             pubkey = node.public_key()
         elif self.tap_subpaths and \
                 (self.tap_subpaths[which_key][0][0] == my_xfp or
                  self.tap_subpaths[which_key][0][0] == swab32(my_xfp)):
             skp = keypath_to_str(self.tap_subpaths[which_key][0])
-            node = sv.derive_path(skp, register=False)
+            node = sv.derive_path(skp, register=True)
             pubkey = node.public_key()[1:]
         else:
             raise AssertionError("Input #%d has no Passport signing path." % my_idx)
@@ -1445,6 +1445,7 @@ class psbtObject(psbtProxy):
         # Important: parse incoming UTXO to build total input value
         missing = 0
         total_in = 0
+        witness_inputs_to_verify = []
 
         for i, txi in self.input_iter():
             gc.collect()
@@ -1474,22 +1475,32 @@ class psbtObject(psbtProxy):
             inp.determine_my_signing_key(i, utxo, self.my_xfp, self)
 
             if inp.witness_utxo and not inp.utxo:
+                # A false amount for an input we prove we sign makes our
+                # signature invalid, and the history cache catches changed
+                # amounts across attempts. Derivation proves the PSBT's
+                # ownership metadata before that argument is applied.
                 if inp.num_our_keys and inp.required_key:
-                    import stash
-                    with stash.SensitiveValues() as sv:
-                        inp.get_signing_node(sv, self.my_xfp, i)
+                    witness_inputs_to_verify.append(i)
                 else:
                     self.fee_is_verified = False
 
             gc.collect()
 
-            # iff to UTXO is segwit, then check it's value, and also
-            # capture that value, since it's supposed to be immutable
+            del utxo
+
+        if witness_inputs_to_verify:
+            import stash
+            with stash.SensitiveValues() as sv:
+                for i in witness_inputs_to_verify:
+                    self.inputs[i].get_signing_node(sv, self.my_xfp, i)
+
+        # Only update the amount cache after all claimed owned inputs have
+        # proved their signing keys, so rejected metadata cannot be recorded.
+        for i, txi in self.input_iter():
+            inp = self.inputs[i]
             if inp.is_segwit:
                 history.verify_amount(txi.prevout, inp.amount, i)
                 gc.collect()
-
-            del utxo
 
         gc.collect()
 

--- a/ports/stm32/boards/Passport/modules/psbt.py
+++ b/ports/stm32/boards/Passport/modules/psbt.py
@@ -643,19 +643,18 @@ class psbtInputProxy(psbtProxy):
         fd = self.fd
         old_pos = fd.tell()
 
+        witness_utxo = None
         if self.witness_utxo:
-            # Going forward? Just what we will witness; no other junk
-            # - prefer this format, altho does that imply segwit txn must be generated?
-            # - I don't know why we wouldn't always use this
-            # - once we use this partial utxo data, we must create witness data out
-            self.is_segwit = True
+            # Load the compact output. If the full previous transaction is also
+            # present, its hash-bound output is loaded below and must match.
 
             fd.seek(self.witness_utxo[0])
-            utxo = CTxOut()
-            utxo.deserialize(fd)
-            fd.seek(old_pos)
+            witness_utxo = CTxOut()
+            witness_utxo.deserialize(fd)
 
-            return utxo
+            if not self.utxo:
+                fd.seek(old_pos)
+                return witness_utxo
 
         assert self.utxo, 'no utxo'
 
@@ -685,6 +684,11 @@ class psbtInputProxy(psbtProxy):
 
         fd.seek(old_pos)
 
+        if witness_utxo:
+            assert witness_utxo.nValue == utxo.nValue and \
+                witness_utxo.scriptPubKey == utxo.scriptPubKey, \
+                "witness/non-witness UTXO mismatch for input #%d" % idx
+
         return utxo
 
     def determine_my_signing_key(self, my_idx, utxo, my_xfp, psbt):
@@ -708,8 +712,18 @@ class psbtInputProxy(psbtProxy):
         which_key = None
 
         addr_type, addr_or_pubkey, addr_is_segwit = utxo.get_address()
-        if addr_is_segwit and not self.is_segwit:
-            self.is_segwit = True
+        self.is_segwit = addr_is_segwit
+
+        if self.witness_utxo and not self.is_segwit:
+            if addr_type == 'p2sh' and self.redeem_script:
+                redeem_script = self.get(self.redeem_script)
+                assert hash160(redeem_script) == addr_or_pubkey, \
+                    "redeem script mismatch for input #%d" % my_idx
+                self.is_segwit = len(redeem_script) in {22, 34} and \
+                    redeem_script[0] == 0 and redeem_script[1] in {20, 32}
+
+            if not self.is_segwit:
+                raise FatalPSBTIssue("Witness UTXO provided for non-SegWit input #%d" % my_idx)
 
         if addr_type == 'p2sh':
             # multisig input
@@ -957,6 +971,7 @@ class psbtObject(psbtProxy):
         self.lock_time = None
         self.total_value_out = None
         self.total_value_in = None
+        self.fee_is_verified = True
         self.presigned_inputs = set()
         self.multisig_import_needs_approval = False
         self.self_send = False
@@ -1269,15 +1284,21 @@ class psbtObject(psbtProxy):
         # print('total_non_change_out={} self.total_value_out={}  total_change={}'.format(total_non_change_out,
         #       self.total_value_out, total_change))
         fee = self.calculate_fee()
+        per_fee = None
         if self.total_value_out == 0:
             per_fee = 100
         elif total_non_change_out == 0:
             self.self_send = True
-        else:
+        elif self.fee_is_verified:
             # Calculate fee based on non-change output value
             per_fee = (fee / total_non_change_out) * 100
 
-        if self.self_send:
+        if not self.fee_is_verified:
+            self.warnings.append(
+                ('Unverified Fee',
+                 'One or more input amounts were supplied by another wallet, '
+                 'so Passport cannot verify the network fee.'))
+        elif self.self_send:
             # self.warnings.append(('Self-Send', 'All outputs are being sent back to this wallet.'))
             per_fee = (fee / self.total_value_out) * 100
             if per_fee >= 5:
@@ -1426,6 +1447,10 @@ class psbtObject(psbtProxy):
             # - also validates redeem_script when present
             # - also finds appropriate multisig wallet to be used
             inp.determine_my_signing_key(i, utxo, self.my_xfp, self)
+
+            if inp.witness_utxo and not inp.utxo and \
+                    not (inp.num_our_keys and inp.required_key):
+                self.fee_is_verified = False
 
             gc.collect()
 

--- a/ports/stm32/boards/Passport/modules/psbt.py
+++ b/ports/stm32/boards/Passport/modules/psbt.py
@@ -857,6 +857,40 @@ class psbtInputProxy(psbtProxy):
         # Could probably free self.subpaths and self.redeem_script now, but only if we didn't
         # need to re-serialize as a PSBT.
 
+    def get_signing_node(self, sv, my_xfp, my_idx):
+        if self.is_multisig:
+            # The fingerprint is only a hint. Derive each candidate to prove
+            # that Passport owns one of the public keys required by the script.
+            for which_key in self.required_key:
+                skp = keypath_to_str(self.subpaths[which_key])
+                node = sv.derive_path(skp, register=False)
+                if node.public_key() == which_key:
+                    return node, which_key
+
+            raise AssertionError("Input #%d needs pubkey this Passport doesn't have." % my_idx)
+
+        which_key = self.required_key
+
+        if self.subpaths and \
+                (self.subpaths[which_key][0] == my_xfp or
+                 self.subpaths[which_key][0] == swab32(my_xfp)):
+            skp = keypath_to_str(self.subpaths[which_key])
+            node = sv.derive_path(skp, register=False)
+            pubkey = node.public_key()
+        elif self.tap_subpaths and \
+                (self.tap_subpaths[which_key][0][0] == my_xfp or
+                 self.tap_subpaths[which_key][0][0] == swab32(my_xfp)):
+            skp = keypath_to_str(self.tap_subpaths[which_key][0])
+            node = sv.derive_path(skp, register=False)
+            pubkey = node.public_key()[1:]
+        else:
+            raise AssertionError("Input #%d has no Passport signing path." % my_idx)
+
+        if pubkey != which_key:
+            raise AssertionError("Path (%s) led to wrong pubkey for input #%d" % (skp, my_idx))
+
+        return node, which_key
+
     def store(self, kt, key, val):
         # Capture what we are interested in.
 
@@ -1439,11 +1473,13 @@ class psbtObject(psbtProxy):
             # - also finds appropriate multisig wallet to be used
             inp.determine_my_signing_key(i, utxo, self.my_xfp, self)
 
-            # A false amount for an input we sign makes our signature invalid,
-            # and the history cache catches changed amounts across attempts.
-            if inp.witness_utxo and not inp.utxo and \
-                    not (inp.num_our_keys and inp.required_key):
-                self.fee_is_verified = False
+            if inp.witness_utxo and not inp.utxo:
+                if inp.num_our_keys and inp.required_key:
+                    import stash
+                    with stash.SensitiveValues() as sv:
+                        inp.get_signing_node(sv, self.my_xfp, i)
+                else:
+                    self.fee_is_verified = False
 
             gc.collect()
 

--- a/ports/stm32/boards/Passport/modules/psbt.py
+++ b/ports/stm32/boards/Passport/modules/psbt.py
@@ -647,6 +647,7 @@ class psbtInputProxy(psbtProxy):
         if self.witness_utxo:
             # Load the compact output. If the full previous transaction is also
             # present, its hash-bound output is loaded below and must match.
+            self.is_segwit = True
 
             fd.seek(self.witness_utxo[0])
             witness_utxo = CTxOut()
@@ -712,18 +713,8 @@ class psbtInputProxy(psbtProxy):
         which_key = None
 
         addr_type, addr_or_pubkey, addr_is_segwit = utxo.get_address()
-        self.is_segwit = addr_is_segwit
-
-        if self.witness_utxo and not self.is_segwit:
-            if addr_type == 'p2sh' and self.redeem_script:
-                redeem_script = self.get(self.redeem_script)
-                assert hash160(redeem_script) == addr_or_pubkey, \
-                    "redeem script mismatch for input #%d" % my_idx
-                self.is_segwit = len(redeem_script) in {22, 34} and \
-                    redeem_script[0] == 0 and redeem_script[1] in {20, 32}
-
-            if not self.is_segwit:
-                raise FatalPSBTIssue("Witness UTXO provided for non-SegWit input #%d" % my_idx)
+        if addr_is_segwit and not self.is_segwit:
+            self.is_segwit = True
 
         if addr_type == 'p2sh':
             # multisig input
@@ -1448,6 +1439,8 @@ class psbtObject(psbtProxy):
             # - also finds appropriate multisig wallet to be used
             inp.determine_my_signing_key(i, utxo, self.my_xfp, self)
 
+            # A false amount for an input we sign makes our signature invalid,
+            # and the history cache catches changed amounts across attempts.
             if inp.witness_utxo and not inp.utxo and \
                     not (inp.num_our_keys and inp.required_key):
                 self.fee_is_verified = False

--- a/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
+++ b/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
@@ -13,7 +13,6 @@
 async def sign_psbt_task(on_done, psbt):
     from exceptions import FraudulentChangeOutput, FatalPSBTIssue
     from errors import Error
-    from utils import keypath_to_str, swab32
     from serializations import ser_sig_der
     import stash
     import gc
@@ -62,51 +61,11 @@ async def sign_psbt_task(on_done, psbt):
                     digest = psbt.make_txn_segwit_sighash(in_idx, txi,
                                                           inp.amount, inp.scriptCode, inp.sighash)
 
-                if inp.is_multisig:
-                    # need to consider a set of possible keys, since xfp may not be unique
-                    for which_key in inp.required_key:
-                        # get node required
-                        skp = keypath_to_str(inp.subpaths[which_key])
-                        node = sv.derive_path(skp, register=False)
+                node, which_key = inp.get_signing_node(sv, psbt.my_xfp, in_idx)
 
-                        # expensive test, but works... and important
-                        pu = node.public_key()
-                        if pu == which_key:
-                            break
-                    else:
-                        raise AssertionError("Input #%d needs pubkey this Passport doesn't have." % in_idx)
-
-                else:
-                    # single pubkey <=> single key
-                    which_key = inp.required_key
-
-                    assert not (inp.added_sig or inp.tap_key_sig), "This transaction has already been signed"
-
-                    if len(inp.subpaths) > 0 and \
-                        (inp.subpaths[which_key][0] == psbt.my_xfp or
-                         inp.subpaths[which_key][0] == swab32(psbt.my_xfp)):
-
-                        # get node required
-                        skp = keypath_to_str(inp.subpaths[which_key])
-                        node = sv.derive_path(skp, register=False)
-
-                        # expensive test, but works... and important
-                        pu = node.public_key()
-
-                    # tap_subpaths have type ([path_elements], [tap_hashes])
-                    elif len(inp.tap_subpaths) > 0 and \
-                        (inp.tap_subpaths[which_key][0][0] == psbt.my_xfp or
-                         inp.tap_subpaths[which_key][0][0] == swab32(psbt.my_xfp)):
-
-                        # get node required
-                        skp = keypath_to_str(inp.tap_subpaths[which_key][0])
-                        node = sv.derive_path(skp, register=False)
-
-                        # expensive test, but works... and important
-                        pu = node.public_key()[1:]
-
-                    if pu != which_key:
-                        raise AssertionError("Path (%s) led to wrong pubkey for input #%d" % (skp, in_idx))
+                if not inp.is_multisig:
+                    assert not (inp.added_sig or inp.tap_key_sig), \
+                        "This transaction has already been signed"
 
                 # The precious private key we need
                 pk = node.private_key()

--- a/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
+++ b/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
@@ -96,7 +96,7 @@ async def sign_psbt_task(on_done, psbt):
                 # private key no longer required
                 stash.blank_object(pk)
                 stash.blank_object(node)
-                del pk, node, pu, skp
+                del pk, node
 
                 # print("result %s" % b2a_hex(result).decode('ascii'))
 

--- a/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
+++ b/ports/stm32/boards/Passport/modules/tasks/sign_psbt_task.py
@@ -46,6 +46,10 @@ async def sign_psbt_task(on_done, psbt):
                     # but in other cases, no more signatures are possible
                     continue
 
+                if not inp.is_multisig:
+                    assert not (inp.added_sig or inp.tap_key_sig), \
+                        "This transaction has already been signed"
+
                 txi.scriptSig = inp.scriptSig
                 if not txi.scriptSig:
                     raise AssertionError('No scriptsig?')
@@ -62,10 +66,6 @@ async def sign_psbt_task(on_done, psbt):
                                                           inp.amount, inp.scriptCode, inp.sighash)
 
                 node, which_key = inp.get_signing_node(sv, psbt.my_xfp, in_idx)
-
-                if not inp.is_multisig:
-                    assert not (inp.added_sig or inp.tap_key_sig), \
-                        "This transaction has already been signed"
 
                 # The precious private key we need
                 pk = node.private_key()

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -38,3 +38,6 @@ def test_psbt_amounts(test):
 
 def test_multisig_xpub_validation(test):
     assert test('multisig_xpub_validation.py') == b'OK'
+
+def test_psbt_fee(test):
+    assert test('psbt_fee.py') == b'OK'

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -39,5 +39,6 @@ def test_psbt_amounts(test):
 def test_multisig_xpub_validation(test):
     assert test('multisig_xpub_validation.py') == b'OK'
 
+
 def test_psbt_fee(test):
     assert test('psbt_fee.py') == b'OK'

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_amounts.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_amounts.py
@@ -37,6 +37,7 @@ class FakeInput:
         self.num_our_keys = 1
         self.required_key = b'key'
         self.is_segwit = False
+        self.witness_utxo = False
 
     def has_utxo(self):
         return True

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
@@ -6,20 +6,17 @@
 from uio import BytesIO
 from ustruct import pack
 
-from exceptions import FatalPSBTIssue
+import history
 from flows.sign_psbt_common_flow import SignPsbtCommonFlow
 from psbt import psbtInputProxy, psbtObject
 from public_constants import (
     PSBT_IN_NON_WITNESS_UTXO,
-    PSBT_IN_REDEEM_SCRIPT,
     PSBT_IN_WITNESS_UTXO,
 )
-from serializations import CTxOut, hash160, ser_compact_size
+from serializations import CTxOut, ser_compact_size
 
 
 P2WPKH_SCRIPT = b'\x00\x14' + (b'\x11' * 20)
-P2PKH_SCRIPT = b'\x76\xa9\x14' + (b'\x22' * 20) + b'\x88\xac'
-DUMMY_PUBKEY = b'\x02' + (b'\x55' * 32)
 
 
 def psbt_field(key_type, value):
@@ -31,13 +28,11 @@ def previous_tx(txout):
     return pack('<i', 2) + b'\x01' + txin + b'\x01' + txout.serialize() + pack('<I', 0)
 
 
-def make_input(witness_txout, non_witness_txout=None, redeem_script=None):
+def make_input(witness_txout, non_witness_txout=None):
     data = b''
     if non_witness_txout:
         data += psbt_field(PSBT_IN_NON_WITNESS_UTXO, previous_tx(non_witness_txout))
     data += psbt_field(PSBT_IN_WITNESS_UTXO, witness_txout.serialize())
-    if redeem_script:
-        data += psbt_field(PSBT_IN_REDEEM_SCRIPT, redeem_script)
     return psbtInputProxy(BytesIO(data + b'\x00'), 0)
 
 
@@ -50,9 +45,11 @@ def assert_raises(exc_type, callback):
 
 
 matching = CTxOut(1000, P2WPKH_SCRIPT)
-loaded = make_input(matching, matching).get_utxo(0)
+matching_input = make_input(matching, matching)
+loaded = matching_input.get_utxo(0)
 assert loaded.nValue == matching.nValue
 assert loaded.scriptPubKey == matching.scriptPubKey
+assert matching_input.is_segwit
 
 amount_mismatch = make_input(CTxOut(999, P2WPKH_SCRIPT), matching)
 assert_raises(AssertionError, lambda: amount_mismatch.get_utxo(0))
@@ -60,32 +57,15 @@ assert_raises(AssertionError, lambda: amount_mismatch.get_utxo(0))
 script_mismatch = make_input(CTxOut(1000, b'\x00\x14' + (b'\x33' * 20)), matching)
 assert_raises(AssertionError, lambda: script_mismatch.get_utxo(0))
 
-legacy = make_input(CTxOut(1000, P2PKH_SCRIPT))
-legacy.subpaths[DUMMY_PUBKEY] = []
-assert_raises(FatalPSBTIssue, lambda: legacy.determine_my_signing_key(0, CTxOut(1000, P2PKH_SCRIPT), 0, None))
 
-native_segwit = make_input(CTxOut(1000, P2WPKH_SCRIPT))
-native_segwit.subpaths[DUMMY_PUBKEY] = []
-native_segwit.determine_my_signing_key(0, CTxOut(1000, P2WPKH_SCRIPT), 0, None)
-assert native_segwit.is_segwit
-
-wrapped_program = b'\x00\x14' + (b'\x44' * 20)
-wrapped_script = b'\xa9\x14' + hash160(wrapped_program) + b'\x87'
-wrapped_segwit = make_input(CTxOut(1000, wrapped_script), redeem_script=wrapped_program)
-wrapped_segwit.subpaths[DUMMY_PUBKEY] = []
-wrapped_segwit.determine_my_signing_key(0, CTxOut(1000, wrapped_script), 0, None)
-assert wrapped_segwit.is_segwit
-
-
-class FakeInput:
-    def __init__(self, owned):
-        self.owned = owned
+class FakeOwnedInput:
+    def __init__(self):
         self.fully_signed = False
         self.witness_utxo = True
         self.utxo = None
         self.required_key = None
-        self.num_our_keys = 1 if owned else 0
-        self.is_segwit = False
+        self.num_our_keys = 1
+        self.is_segwit = True
         self.subpaths = {}
         self.tap_subpaths = {}
 
@@ -97,7 +77,7 @@ class FakeInput:
 
     def determine_my_signing_key(self, _idx, utxo, _xfp, _psbt):
         self.amount = utxo.nValue
-        self.required_key = b'key' if self.owned else None
+        self.required_key = b'key'
 
 
 class FakePrevout:
@@ -109,8 +89,8 @@ class FakeTxIn:
 
 
 class FakeInputPSBT:
-    def __init__(self, owned):
-        self.inputs = [FakeInput(owned)]
+    def __init__(self, psbt_input):
+        self.inputs = [psbt_input]
         self.my_xfp = 0
         self.total_value_in = None
         self.fee_is_verified = True
@@ -122,13 +102,21 @@ class FakeInputPSBT:
         yield 0, FakeTxIn()
 
 
-external_input_psbt = FakeInputPSBT(False)
-psbtObject.consider_inputs(external_input_psbt)
-assert not external_input_psbt.fee_is_verified
+verified_amounts = []
+original_verify_amount = history.verify_amount
+history.verify_amount = lambda _prevout, amount, idx: verified_amounts.append((amount, idx))
+try:
+    external_input_psbt = FakeInputPSBT(make_input(CTxOut(2000, P2WPKH_SCRIPT)))
+    psbtObject.consider_inputs(external_input_psbt)
+    assert not external_input_psbt.fee_is_verified
 
-owned_input_psbt = FakeInputPSBT(True)
-psbtObject.consider_inputs(owned_input_psbt)
-assert owned_input_psbt.fee_is_verified
+    owned_input_psbt = FakeInputPSBT(FakeOwnedInput())
+    psbtObject.consider_inputs(owned_input_psbt)
+    assert owned_input_psbt.fee_is_verified
+finally:
+    history.verify_amount = original_verify_amount
+
+assert verified_amounts == [(2000, 0), (2000, 0)]
 
 
 class FakeOutputProxy:
@@ -159,12 +147,12 @@ class FakeOutputPSBT:
         pass
 
 
-unverified_fee_psbt = FakeOutputPSBT(False)
+unverified_fee_psbt = FakeOutputPSBT(external_input_psbt.fee_is_verified)
 psbtObject.consider_outputs(unverified_fee_psbt)
 assert unverified_fee_psbt.warnings[0][0] == 'Unverified Fee'
 assert all(label not in {'Big Fee', 'Huge Fee'} for label, _text in unverified_fee_psbt.warnings)
 
-verified_fee_psbt = FakeOutputPSBT(True)
+verified_fee_psbt = FakeOutputPSBT(owned_input_psbt.fee_is_verified)
 psbtObject.consider_outputs(verified_fee_psbt)
 assert verified_fee_psbt.warnings[0][0] == 'Huge Fee'
 

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
@@ -22,6 +22,11 @@ P2WPKH_SCRIPT = b'\x00\x14' + (b'\x11' * 20)
 MY_XFP = 0x12345678
 OWNED_PUBKEY = b'\x02' + (b'\x55' * 32)
 FORGED_PUBKEY = b'\x03' + (b'\x66' * 32)
+TAPROOT_PUBKEY = b'\x77' * 32
+DERIVED_PUBKEYS = {
+    'm/0': OWNED_PUBKEY,
+    'm/1': b'\x02' + TAPROOT_PUBKEY,
+}
 
 
 def psbt_field(key_type, value, key=b''):
@@ -80,9 +85,11 @@ class FakeTxIn:
 
 
 class FakeNode:
-    @staticmethod
-    def public_key():
-        return OWNED_PUBKEY
+    def __init__(self, public_key):
+        self._public_key = public_key
+
+    def public_key(self):
+        return self._public_key
 
 
 class FakeSensitiveValues:
@@ -93,10 +100,13 @@ class FakeSensitiveValues:
         pass
 
     @staticmethod
-    def derive_path(path, register=False):
-        assert path == 'm/0'
-        assert not register
-        return FakeNode()
+    def derive_path(path, register=True):
+        assert register
+        return FakeNode(DERIVED_PUBKEYS[path])
+
+
+class FakeSigningInput:
+    pass
 
 
 class FakeInputPSBT:
@@ -140,6 +150,36 @@ finally:
     stash.SensitiveValues = original_sensitive_values
 
 assert verified_amounts == [(2000, 0), (2000, 0)]
+
+multisig_input = FakeSigningInput()
+multisig_input.is_multisig = True
+multisig_input.required_key = {OWNED_PUBKEY}
+multisig_input.subpaths = {OWNED_PUBKEY: [MY_XFP, 0]}
+node, which_key = psbtInputProxy.get_signing_node(
+    multisig_input, FakeSensitiveValues(), MY_XFP, 0)
+assert node.public_key() == OWNED_PUBKEY
+assert which_key == OWNED_PUBKEY
+
+taproot_input = FakeSigningInput()
+taproot_input.is_multisig = False
+taproot_input.required_key = TAPROOT_PUBKEY
+taproot_input.subpaths = {}
+taproot_input.tap_subpaths = {TAPROOT_PUBKEY: ([MY_XFP, 1], [])}
+node, which_key = psbtInputProxy.get_signing_node(
+    taproot_input, FakeSensitiveValues(), MY_XFP, 0)
+assert node.public_key()[1:] == TAPROOT_PUBKEY
+assert which_key == TAPROOT_PUBKEY
+
+missing_path_input = FakeSigningInput()
+missing_path_input.is_multisig = False
+missing_path_input.required_key = OWNED_PUBKEY
+missing_path_input.subpaths = {}
+missing_path_input.tap_subpaths = {}
+assert_raises(
+    AssertionError,
+    lambda: psbtInputProxy.get_signing_node(
+        missing_path_input, FakeSensitiveValues(), MY_XFP, 0),
+)
 
 
 class FakeOutputProxy:

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
@@ -10,17 +10,22 @@ import history
 from flows.sign_psbt_common_flow import SignPsbtCommonFlow
 from psbt import psbtInputProxy, psbtObject
 from public_constants import (
+    PSBT_IN_BIP32_DERIVATION,
     PSBT_IN_NON_WITNESS_UTXO,
     PSBT_IN_WITNESS_UTXO,
 )
-from serializations import CTxOut, ser_compact_size
+from serializations import CTxOut, hash160, ser_compact_size
 
 
 P2WPKH_SCRIPT = b'\x00\x14' + (b'\x11' * 20)
+MY_XFP = 0x12345678
+OWNED_PUBKEY = b'\x02' + (b'\x55' * 32)
+OWNED_SCRIPT = b'\x00\x14' + hash160(OWNED_PUBKEY)
 
 
-def psbt_field(key_type, value):
-    return b'\x01' + bytes([key_type]) + ser_compact_size(len(value)) + value
+def psbt_field(key_type, value, key=b''):
+    full_key = bytes([key_type]) + key
+    return ser_compact_size(len(full_key)) + full_key + ser_compact_size(len(value)) + value
 
 
 def previous_tx(txout):
@@ -33,6 +38,13 @@ def make_input(witness_txout, non_witness_txout=None):
     if non_witness_txout:
         data += psbt_field(PSBT_IN_NON_WITNESS_UTXO, previous_tx(non_witness_txout))
     data += psbt_field(PSBT_IN_WITNESS_UTXO, witness_txout.serialize())
+    return psbtInputProxy(BytesIO(data + b'\x00'), 0)
+
+
+def make_owned_input():
+    txout = CTxOut(2000, OWNED_SCRIPT)
+    data = psbt_field(PSBT_IN_WITNESS_UTXO, txout.serialize())
+    data += psbt_field(PSBT_IN_BIP32_DERIVATION, pack('<II', MY_XFP, 0), OWNED_PUBKEY)
     return psbtInputProxy(BytesIO(data + b'\x00'), 0)
 
 
@@ -58,28 +70,6 @@ script_mismatch = make_input(CTxOut(1000, b'\x00\x14' + (b'\x33' * 20)), matchin
 assert_raises(AssertionError, lambda: script_mismatch.get_utxo(0))
 
 
-class FakeOwnedInput:
-    def __init__(self):
-        self.fully_signed = False
-        self.witness_utxo = True
-        self.utxo = None
-        self.required_key = None
-        self.num_our_keys = 1
-        self.is_segwit = True
-        self.subpaths = {}
-        self.tap_subpaths = {}
-
-    def has_utxo(self):
-        return True
-
-    def get_utxo(self, _idx):
-        return CTxOut(2000, P2WPKH_SCRIPT)
-
-    def determine_my_signing_key(self, _idx, utxo, _xfp, _psbt):
-        self.amount = utxo.nValue
-        self.required_key = b'key'
-
-
 class FakePrevout:
     n = 0
 
@@ -89,9 +79,9 @@ class FakeTxIn:
 
 
 class FakeInputPSBT:
-    def __init__(self, psbt_input):
+    def __init__(self, psbt_input, my_xfp=0):
         self.inputs = [psbt_input]
-        self.my_xfp = 0
+        self.my_xfp = my_xfp
         self.total_value_in = None
         self.fee_is_verified = True
         self.presigned_inputs = set()
@@ -110,9 +100,13 @@ try:
     psbtObject.consider_inputs(external_input_psbt)
     assert not external_input_psbt.fee_is_verified
 
-    owned_input_psbt = FakeInputPSBT(FakeOwnedInput())
+    owned_input = make_owned_input()
+    owned_input.validate(0, FakeTxIn(), MY_XFP)
+    owned_input_psbt = FakeInputPSBT(owned_input, MY_XFP)
     psbtObject.consider_inputs(owned_input_psbt)
     assert owned_input_psbt.fee_is_verified
+    assert owned_input.num_our_keys == 1
+    assert owned_input.required_key == OWNED_PUBKEY
 finally:
     history.verify_amount = original_verify_amount
 

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
@@ -7,6 +7,7 @@ from uio import BytesIO
 from ustruct import pack
 
 import history
+import stash
 from flows.sign_psbt_common_flow import SignPsbtCommonFlow
 from psbt import psbtInputProxy, psbtObject
 from public_constants import (
@@ -20,7 +21,7 @@ from serializations import CTxOut, hash160, ser_compact_size
 P2WPKH_SCRIPT = b'\x00\x14' + (b'\x11' * 20)
 MY_XFP = 0x12345678
 OWNED_PUBKEY = b'\x02' + (b'\x55' * 32)
-OWNED_SCRIPT = b'\x00\x14' + hash160(OWNED_PUBKEY)
+FORGED_PUBKEY = b'\x03' + (b'\x66' * 32)
 
 
 def psbt_field(key_type, value, key=b''):
@@ -41,10 +42,10 @@ def make_input(witness_txout, non_witness_txout=None):
     return psbtInputProxy(BytesIO(data + b'\x00'), 0)
 
 
-def make_owned_input():
-    txout = CTxOut(2000, OWNED_SCRIPT)
+def make_owned_input(pubkey=OWNED_PUBKEY):
+    txout = CTxOut(2000, b'\x00\x14' + hash160(pubkey))
     data = psbt_field(PSBT_IN_WITNESS_UTXO, txout.serialize())
-    data += psbt_field(PSBT_IN_BIP32_DERIVATION, pack('<II', MY_XFP, 0), OWNED_PUBKEY)
+    data += psbt_field(PSBT_IN_BIP32_DERIVATION, pack('<II', MY_XFP, 0), pubkey)
     return psbtInputProxy(BytesIO(data + b'\x00'), 0)
 
 
@@ -78,6 +79,26 @@ class FakeTxIn:
     prevout = FakePrevout()
 
 
+class FakeNode:
+    @staticmethod
+    def public_key():
+        return OWNED_PUBKEY
+
+
+class FakeSensitiveValues:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        pass
+
+    @staticmethod
+    def derive_path(path, register=False):
+        assert path == 'm/0'
+        assert not register
+        return FakeNode()
+
+
 class FakeInputPSBT:
     def __init__(self, psbt_input, my_xfp=0):
         self.inputs = [psbt_input]
@@ -94,7 +115,9 @@ class FakeInputPSBT:
 
 verified_amounts = []
 original_verify_amount = history.verify_amount
+original_sensitive_values = stash.SensitiveValues
 history.verify_amount = lambda _prevout, amount, idx: verified_amounts.append((amount, idx))
+stash.SensitiveValues = FakeSensitiveValues
 try:
     external_input_psbt = FakeInputPSBT(make_input(CTxOut(2000, P2WPKH_SCRIPT)))
     psbtObject.consider_inputs(external_input_psbt)
@@ -107,8 +130,14 @@ try:
     assert owned_input_psbt.fee_is_verified
     assert owned_input.num_our_keys == 1
     assert owned_input.required_key == OWNED_PUBKEY
+
+    forged_input = make_owned_input(FORGED_PUBKEY)
+    forged_input.validate(0, FakeTxIn(), MY_XFP)
+    forged_input_psbt = FakeInputPSBT(forged_input, MY_XFP)
+    assert_raises(AssertionError, lambda: psbtObject.consider_inputs(forged_input_psbt))
 finally:
     history.verify_amount = original_verify_amount
+    stash.SensitiveValues = original_sensitive_values
 
 assert verified_amounts == [(2000, 0), (2000, 0)]
 

--- a/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Test PSBT input-value validation and fee review rendering.
+
+from uio import BytesIO
+from ustruct import pack
+
+from exceptions import FatalPSBTIssue
+from flows.sign_psbt_common_flow import SignPsbtCommonFlow
+from psbt import psbtInputProxy, psbtObject
+from public_constants import (
+    PSBT_IN_NON_WITNESS_UTXO,
+    PSBT_IN_REDEEM_SCRIPT,
+    PSBT_IN_WITNESS_UTXO,
+)
+from serializations import CTxOut, hash160, ser_compact_size
+
+
+P2WPKH_SCRIPT = b'\x00\x14' + (b'\x11' * 20)
+P2PKH_SCRIPT = b'\x76\xa9\x14' + (b'\x22' * 20) + b'\x88\xac'
+DUMMY_PUBKEY = b'\x02' + (b'\x55' * 32)
+
+
+def psbt_field(key_type, value):
+    return b'\x01' + bytes([key_type]) + ser_compact_size(len(value)) + value
+
+
+def previous_tx(txout):
+    txin = (b'\x00' * 32) + pack('<I', 0) + b'\x00' + pack('<I', 0xffffffff)
+    return pack('<i', 2) + b'\x01' + txin + b'\x01' + txout.serialize() + pack('<I', 0)
+
+
+def make_input(witness_txout, non_witness_txout=None, redeem_script=None):
+    data = b''
+    if non_witness_txout:
+        data += psbt_field(PSBT_IN_NON_WITNESS_UTXO, previous_tx(non_witness_txout))
+    data += psbt_field(PSBT_IN_WITNESS_UTXO, witness_txout.serialize())
+    if redeem_script:
+        data += psbt_field(PSBT_IN_REDEEM_SCRIPT, redeem_script)
+    return psbtInputProxy(BytesIO(data + b'\x00'), 0)
+
+
+def assert_raises(exc_type, callback):
+    try:
+        callback()
+    except exc_type:
+        return
+    raise AssertionError('Expected {}'.format(exc_type))
+
+
+matching = CTxOut(1000, P2WPKH_SCRIPT)
+loaded = make_input(matching, matching).get_utxo(0)
+assert loaded.nValue == matching.nValue
+assert loaded.scriptPubKey == matching.scriptPubKey
+
+amount_mismatch = make_input(CTxOut(999, P2WPKH_SCRIPT), matching)
+assert_raises(AssertionError, lambda: amount_mismatch.get_utxo(0))
+
+script_mismatch = make_input(CTxOut(1000, b'\x00\x14' + (b'\x33' * 20)), matching)
+assert_raises(AssertionError, lambda: script_mismatch.get_utxo(0))
+
+legacy = make_input(CTxOut(1000, P2PKH_SCRIPT))
+legacy.subpaths[DUMMY_PUBKEY] = []
+assert_raises(FatalPSBTIssue, lambda: legacy.determine_my_signing_key(0, CTxOut(1000, P2PKH_SCRIPT), 0, None))
+
+native_segwit = make_input(CTxOut(1000, P2WPKH_SCRIPT))
+native_segwit.subpaths[DUMMY_PUBKEY] = []
+native_segwit.determine_my_signing_key(0, CTxOut(1000, P2WPKH_SCRIPT), 0, None)
+assert native_segwit.is_segwit
+
+wrapped_program = b'\x00\x14' + (b'\x44' * 20)
+wrapped_script = b'\xa9\x14' + hash160(wrapped_program) + b'\x87'
+wrapped_segwit = make_input(CTxOut(1000, wrapped_script), redeem_script=wrapped_program)
+wrapped_segwit.subpaths[DUMMY_PUBKEY] = []
+wrapped_segwit.determine_my_signing_key(0, CTxOut(1000, wrapped_script), 0, None)
+assert wrapped_segwit.is_segwit
+
+
+class FakeInput:
+    def __init__(self, owned):
+        self.owned = owned
+        self.fully_signed = False
+        self.witness_utxo = True
+        self.utxo = None
+        self.required_key = None
+        self.num_our_keys = 1 if owned else 0
+        self.is_segwit = False
+        self.subpaths = {}
+        self.tap_subpaths = {}
+
+    def has_utxo(self):
+        return True
+
+    def get_utxo(self, _idx):
+        return CTxOut(2000, P2WPKH_SCRIPT)
+
+    def determine_my_signing_key(self, _idx, utxo, _xfp, _psbt):
+        self.amount = utxo.nValue
+        self.required_key = b'key' if self.owned else None
+
+
+class FakePrevout:
+    n = 0
+
+
+class FakeTxIn:
+    prevout = FakePrevout()
+
+
+class FakeInputPSBT:
+    def __init__(self, owned):
+        self.inputs = [FakeInput(owned)]
+        self.my_xfp = 0
+        self.total_value_in = None
+        self.fee_is_verified = True
+        self.presigned_inputs = set()
+        self.num_inputs = 1
+        self.warnings = []
+
+    def input_iter(self):
+        yield 0, FakeTxIn()
+
+
+external_input_psbt = FakeInputPSBT(False)
+psbtObject.consider_inputs(external_input_psbt)
+assert not external_input_psbt.fee_is_verified
+
+owned_input_psbt = FakeInputPSBT(True)
+psbtObject.consider_inputs(owned_input_psbt)
+assert owned_input_psbt.fee_is_verified
+
+
+class FakeOutputProxy:
+    is_change = False
+
+    def validate(self, _idx, _txout, _xfp, _active_multisig):
+        pass
+
+
+class FakeOutputPSBT:
+    def __init__(self, fee_is_verified):
+        self.outputs = [FakeOutputProxy()]
+        self.total_value_out = 1000
+        self.total_value_in = 5000
+        self.fee_is_verified = fee_is_verified
+        self.self_send = False
+        self.warnings = []
+        self.my_xfp = 0
+        self.active_multisig = None
+
+    def output_iter(self):
+        yield 0, CTxOut(self.total_value_out, P2WPKH_SCRIPT)
+
+    def calculate_fee(self):
+        return self.total_value_in - self.total_value_out
+
+    def consider_dangerous_change(self, _xfp):
+        pass
+
+
+unverified_fee_psbt = FakeOutputPSBT(False)
+psbtObject.consider_outputs(unverified_fee_psbt)
+assert unverified_fee_psbt.warnings[0][0] == 'Unverified Fee'
+assert all(label not in {'Big Fee', 'Huge Fee'} for label, _text in unverified_fee_psbt.warnings)
+
+verified_fee_psbt = FakeOutputPSBT(True)
+psbtObject.consider_outputs(verified_fee_psbt)
+assert verified_fee_psbt.warnings[0][0] == 'Huge Fee'
+
+
+class FakeChain:
+    def render_value(self, value):
+        return str(value), 'sats'
+
+
+class FakeFlow:
+    chain = FakeChain()
+
+    def __init__(self, psbt):
+        self.psbt = psbt
+
+
+review = SignPsbtCommonFlow.render_warnings(FakeFlow(unverified_fee_psbt))
+assert 'Unverified' in review
+assert '4000 sats' not in review
+
+review = SignPsbtCommonFlow.render_warnings(FakeFlow(verified_fee_psbt))
+assert '4000 sats' in review
+
+return_value.write(b'OK')


### PR DESCRIPTION
## Summary

- cross-check `witness_utxo` against the hash-verified previous transaction when both PSBT fields are present
- mark fees as unverified when collaborative inputs provide only unbound witness amounts
- suppress misleading percentage warnings and display an explicit unverified-fee warning
- preserve existing SegWit classification, history-cache, and serialization behavior
- add parser, fee-policy, history-cache, and review-rendering regression coverage

## Impact

Ordinary single-wallet SegWit transactions continue to display their network fee. Witness-only amounts for inputs Passport will sign retain the existing numeric display because the signature commits to that input amount and the history cache detects changed amounts across signing attempts.

Collaborative transactions whose external input amounts cannot be independently checked now identify the fee as unverified instead of displaying an attacker-controlled value.

## Testing

- focused PSBT fee unit script under CPython with MicroPython compatibility stubs
- `python -m py_compile` on changed Python files
- `python -m pycodestyle` on changed Python files
- `python -m reuse lint-file ports/stm32/boards/Passport/modules/tests/unit/psbt_fee.py`
- `git diff --check`

The native Unix simulator build was not available locally; GitHub CI provides the firmware and simulator build validation.