### PR TITLE
Reject oversized QR grids in quirc

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: fsfe/reuse-action@v6
 
+  quirc-tests-pass:
+    name: quirc tests pass?
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: make -C extmod/quirc/tests test
+
   rust-code-compiles:
     name: Rust code compiles?
     runs-on: ubuntu-latest

--- a/extmod/quirc/decode.c
+++ b/extmod/quirc/decode.c
@@ -891,6 +891,9 @@ quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 {
 	quirc_decode_error_t err;
 
+	if (code->size > QUIRC_MAX_GRID_SIZE)
+		return QUIRC_ERROR_INVALID_GRID_SIZE;
+
 	if ((code->size - 17) % 4)
 		return QUIRC_ERROR_INVALID_GRID_SIZE;
 

--- a/extmod/quirc/identify.c
+++ b/extmod/quirc/identify.c
@@ -728,9 +728,9 @@ static int measure_timing_pattern(struct quirc *q, int index)
 	/* Choose the nearest allowable grid size */
 	size = scan * 2 + 13;
 	ver = (size - 15) / 4;
-	qr->grid_size = ver * 4 + 17;
-	if (qr->grid_size > QUIRC_MAX_GRID_SIZE)
+	if (ver < 1 || ver > QUIRC_MAX_VERSION)
 		return -1;
+	qr->grid_size = ver * 4 + 17;
 
 	return 0;
 }
@@ -1237,6 +1237,10 @@ void quirc_extract(const struct quirc *q, int index,
 	perspective_map(qr->c, 0.0, qr->grid_size, &code->corners[3]);
 
 	code->size = qr->grid_size;
+
+	/* Skip out early so as not to overrun the buffer. quirc_decode
+	 * will return an error on interpreting the code.
+	 */
 	if (code->size > QUIRC_MAX_GRID_SIZE)
 		return;
 

--- a/extmod/quirc/identify.c
+++ b/extmod/quirc/identify.c
@@ -729,6 +729,8 @@ static int measure_timing_pattern(struct quirc *q, int index)
 	size = scan * 2 + 13;
 	ver = (size - 15) / 4;
 	qr->grid_size = ver * 4 + 17;
+	if (qr->grid_size > QUIRC_MAX_GRID_SIZE)
+		return -1;
 
 	return 0;
 }
@@ -1217,14 +1219,16 @@ void quirc_end(struct quirc *q)
 void quirc_extract(const struct quirc *q, int index,
 				   struct quirc_code *code)
 {
-	const struct quirc_grid *qr = &q->grids[index];
+	const struct quirc_grid *qr;
 	int y;
 	int i = 0;
 
-	if (index < 0 || index > q->num_grids)
+	memset(code, 0, sizeof(*code));
+
+	if (index < 0 || index >= q->num_grids)
 		return;
 
-	memset(code, 0, sizeof(*code));
+	qr = &q->grids[index];
 
 	perspective_map(qr->c, 0.0, 0.0, &code->corners[0]);
 	perspective_map(qr->c, qr->grid_size, 0.0, &code->corners[1]);
@@ -1233,6 +1237,8 @@ void quirc_extract(const struct quirc *q, int index,
 	perspective_map(qr->c, 0.0, qr->grid_size, &code->corners[3]);
 
 	code->size = qr->grid_size;
+	if (code->size > QUIRC_MAX_GRID_SIZE)
+		return;
 
 	for (y = 0; y < qr->grid_size; y++)
 	{

--- a/extmod/quirc/quirc.h
+++ b/extmod/quirc/quirc.h
@@ -91,7 +91,9 @@ typedef enum {
 const char *quirc_strerror(quirc_decode_error_t err);
 
 /* Limits on the maximum size of QR-codes and their content. */
-#define QUIRC_MAX_BITMAP	3917
+#define QUIRC_MAX_VERSION	40
+#define QUIRC_MAX_GRID_SIZE	(QUIRC_MAX_VERSION * 4 + 17)
+#define QUIRC_MAX_BITMAP	(((QUIRC_MAX_GRID_SIZE * QUIRC_MAX_GRID_SIZE) + 7) / 8)
 #define QUIRC_MAX_PAYLOAD	8896
 
 /* QR-code ECC types. */

--- a/extmod/quirc/quirc.h
+++ b/extmod/quirc/quirc.h
@@ -90,9 +90,16 @@ typedef enum {
 /* Return a string error message for an error code. */
 const char *quirc_strerror(quirc_decode_error_t err);
 
-/* Limits on the maximum size of QR-codes and their content. */
+/* Limits on the maximum size of QR-codes and their content.
+ *
+ * ISO/IEC 18004:2024, 5.1, defines QR Code versions 1 through 40. Version 1
+ * is 21 modules per side and each version adds four modules per side, so the
+ * Version 40 limit is 4 * 40 + 17 = 177 modules.
+ * https://www.qrcode.com/en/about/version.html/index.html
+ */
 #define QUIRC_MAX_VERSION	40
 #define QUIRC_MAX_GRID_SIZE	(QUIRC_MAX_VERSION * 4 + 17)
+/* One bit per module, rounded up to whole bytes: ceil(177 * 177 / 8) = 3917. */
 #define QUIRC_MAX_BITMAP	(((QUIRC_MAX_GRID_SIZE * QUIRC_MAX_GRID_SIZE) + 7) / 8)
 #define QUIRC_MAX_PAYLOAD	8896
 

--- a/extmod/quirc/quirc_internal.h
+++ b/extmod/quirc/quirc_internal.h
@@ -100,7 +100,6 @@ struct quirc {
  * QR-code version information database
  */
 
-#define QUIRC_MAX_VERSION     40
 #define QUIRC_MAX_ALIGNMENT   7
 
 struct quirc_rs_params {

--- a/extmod/quirc/tests/Makefile
+++ b/extmod/quirc/tests/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+QUIRC_DIR := ..
+PASSPORT_INCLUDE := ../../../ports/stm32/boards/Passport/include
+SOURCES := test_grid_bounds.c \
+	$(QUIRC_DIR)/identify.c \
+	$(QUIRC_DIR)/decode.c \
+	$(QUIRC_DIR)/quirc.c \
+	$(QUIRC_DIR)/version_db.c
+
+CFLAGS += -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter
+CFLAGS += -fsanitize=address,undefined -fno-omit-frame-pointer
+LDFLAGS += -fsanitize=address,undefined -lm
+
+.PHONY: test clean
+
+test: test_grid_bounds
+	./test_grid_bounds
+
+test_grid_bounds: $(SOURCES)
+	$(CC) $(CFLAGS) -I$(QUIRC_DIR) -I$(PASSPORT_INCLUDE) $^ $(LDFLAGS) -o $@
+
+clean:
+	rm -f test_grid_bounds

--- a/extmod/quirc/tests/Makefile
+++ b/extmod/quirc/tests/Makefile
@@ -9,7 +9,7 @@ SOURCES := test_grid_bounds.c \
 	$(QUIRC_DIR)/quirc.c \
 	$(QUIRC_DIR)/version_db.c
 
-CFLAGS += -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter
+CFLAGS += -g -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter
 CFLAGS += -fsanitize=address,undefined -fno-omit-frame-pointer
 LDFLAGS += -fsanitize=address,undefined -lm
 

--- a/extmod/quirc/tests/test_grid_bounds.c
+++ b/extmod/quirc/tests/test_grid_bounds.c
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "quirc_internal.h"
+
+#define CANARY_SIZE 16
+#define CANARY_BYTE 0xa5
+
+struct guarded_code {
+	uint8_t before[CANARY_SIZE];
+	struct quirc_code code;
+	uint8_t after[CANARY_SIZE];
+};
+
+static void assert_canaries(const struct guarded_code *guarded)
+{
+	int i;
+
+	for (i = 0; i < CANARY_SIZE; i++) {
+		assert(guarded->before[i] == CANARY_BYTE);
+		assert(guarded->after[i] == CANARY_BYTE);
+	}
+}
+
+static void test_extract_rejects_index_at_count(void)
+{
+	struct quirc q;
+	struct guarded_code guarded;
+
+	memset(&q, 0, sizeof(q));
+	memset(&guarded, CANARY_BYTE, sizeof(guarded));
+	q.num_grids = 1;
+	q.grids[1].grid_size = 21;
+
+	quirc_extract(&q, 1, &guarded.code);
+
+	assert(guarded.code.size == 0);
+	assert_canaries(&guarded);
+}
+
+static void test_extract_rejects_oversized_grid(void)
+{
+	struct quirc q;
+	struct guarded_code guarded;
+	quirc_pixel_t pixel = QUIRC_PIXEL_BLACK;
+
+	memset(&q, 0, sizeof(q));
+	memset(&guarded, CANARY_BYTE, sizeof(guarded));
+
+	q.pixels = &pixel;
+	q.w = 1;
+	q.h = 1;
+	q.num_grids = 1;
+	q.grids[0].grid_size = QUIRC_MAX_GRID_SIZE + 4;
+
+	quirc_extract(&q, 0, &guarded.code);
+
+	assert(guarded.code.size == QUIRC_MAX_GRID_SIZE + 4);
+	assert_canaries(&guarded);
+}
+
+static void test_extract_accepts_maximum_grid(void)
+{
+	struct quirc q;
+	struct guarded_code guarded;
+	quirc_pixel_t pixel = QUIRC_PIXEL_BLACK;
+
+	memset(&q, 0, sizeof(q));
+	memset(&guarded, CANARY_BYTE, sizeof(guarded));
+
+	q.pixels = &pixel;
+	q.w = 1;
+	q.h = 1;
+	q.num_grids = 1;
+	q.grids[0].grid_size = QUIRC_MAX_GRID_SIZE;
+
+	quirc_extract(&q, 0, &guarded.code);
+
+	assert(guarded.code.size == QUIRC_MAX_GRID_SIZE);
+	assert(guarded.code.cell_bitmap[QUIRC_MAX_BITMAP - 1] == 1);
+	assert_canaries(&guarded);
+}
+
+static void test_decode_rejects_oversized_grid(void)
+{
+	struct quirc_code code;
+	struct quirc_data data;
+
+	memset(&code, 0, sizeof(code));
+	code.size = QUIRC_MAX_GRID_SIZE + 4;
+
+	assert(quirc_decode(&code, &data) == QUIRC_ERROR_INVALID_GRID_SIZE);
+}
+
+static void test_decode_accepts_maximum_grid_size(void)
+{
+	struct quirc_code code;
+	struct quirc_data data;
+
+	memset(&code, 0, sizeof(code));
+	code.size = QUIRC_MAX_GRID_SIZE;
+
+	assert(quirc_decode(&code, &data) != QUIRC_ERROR_INVALID_GRID_SIZE);
+}
+
+int main(void)
+{
+	test_extract_rejects_index_at_count();
+	test_extract_rejects_oversized_grid();
+	test_extract_accepts_maximum_grid();
+	test_decode_rejects_oversized_grid();
+	test_decode_accepts_maximum_grid_size();
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

- restore quirc's derived maximum QR grid and bitmap size constants
- reject detector results above QR version 40 before recording the grid
- stop extraction and decoding before oversized grids can access the fixed cell bitmap
- reject `quirc_extract()` indices equal to the detected grid count
- add host regression coverage for the extraction and decode boundaries

## Rationale

The detector can infer a grid larger than the maximum QR version from a malformed QR-like image. `quirc_extract()` previously trusted that size and could write beyond `quirc_code.cell_bitmap`. The extraction and decode guards restore the upstream memory-safety fix, while the identification check rejects the invalid grid earlier.

Valid QR grids, including the maximum 177 by 177 version 40 grid, remain accepted.

## Testing

- `make -C extmod/quirc/tests clean test` with AddressSanitizer and UndefinedBehaviorSanitizer
- host compile and test with GCC 13.2 using `-Wall -Wextra -Werror`
- `git diff --check`
- REUSE lint on the new test files