### PR TITLE
Fix wallet policy import from UR bytes

### DIFF
--- a/ports/stm32/boards/Passport/modules/policy_transport.py
+++ b/ports/stm32/boards/Passport/modules/policy_transport.py
@@ -69,7 +69,7 @@ def _network_mismatch_message(network):
 
 def decode_policy_transport(data, chain, master_xfp, derive_node,
                             default_name='Wallet Policy'):
-    if isinstance(data, bytes):
+    if isinstance(data, (bytes, bytearray)):
         try:
             data = data.decode('utf-8')
         except UnicodeError:

--- a/ports/stm32/boards/Passport/modules/tests/host/test_wallet_policy.py
+++ b/ports/stm32/boards/Passport/modules/tests/host/test_wallet_policy.py
@@ -306,9 +306,9 @@ def test_registry_preserves_settings_headroom():
         registry.save(make_policy())
 
 
-def test_policy_transport_round_trip_rediscovers_owned_key():
+def test_policy_transport_qr_bytes_round_trip_rediscovers_owned_key():
     policy = make_policy()
-    encoded = encode_policy_transport(policy)
+    encoded = bytearray(encode_policy_transport(policy).encode('utf-8'))
     decoded = decode_policy_transport(
         encoded, DerivationChain(),
         int.from_bytes(bytes.fromhex('6738736c'), 'little'),


### PR DESCRIPTION
## Summary

- Accept both `bytes` and `bytearray` wallet-policy payloads.
- Update the existing transport round-trip test to exercise the `bytearray` returned by QR decoding.

## Why

Wallet-policy QR import accepts `UR:BYTES`, but Passport's native UR decoder returns the decoded payload as a `bytearray`. `decode_policy_transport` only normalized `bytes`, causing valid wallet-policy QRs to fail with:

> Wallet policy transport must be text

This does not change the QR or wallet-policy transport format.

## Testing

- All 94 wallet-policy host tests pass.
- Changed files pass `pycodestyle`.
- Verified wallet-policy registration and receive-address verification with the Passport simulator.
