### PR TITLE
Validate complete local multisig xpubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 ## Head
+- Validate the complete local xpub when importing multisig wallets
 - Require confirmation before using PSBT-proposed multisig wallets with temporary seeds,
   and cancel signing if import is declined
 - Added Coconut Wallet as a single-sig Connect Wallet option

--- a/ports/stm32/boards/Passport/modules/multisig_wallet.py
+++ b/ports/stm32/boards/Passport/modules/multisig_wallet.py
@@ -798,8 +798,9 @@ configured derivation path length = (%d).' % (xfp2str(xfp), p_len, depth)
             #   and that's not supported
             with stash.SensitiveValues() as sv:
                 chk_node = sv.derive_path(deriv)
-                assert node.public_key() == chk_node.public_key(), \
-                    "(m=%s)/%s wrong pubkey" % (xfp2str(xfp), deriv[2:])
+                assert node.public_key() == chk_node.public_key() and \
+                    node.chain_code() == chk_node.chain_code(), \
+                    "(m=%s)/%s wrong xpub" % (xfp2str(xfp), deriv[2:])
 
         # serialize xpub w/ BIP32 standard now.
         # - this has effect of stripping SLIP-132 confusion away

--- a/ports/stm32/boards/Passport/modules/tests/test_unit.py
+++ b/ports/stm32/boards/Passport/modules/tests/test_unit.py
@@ -34,3 +34,7 @@ def test_foundation(test):
 
 def test_psbt_amounts(test):
     assert test('psbt_amounts.py') == b'OK'
+
+
+def test_multisig_xpub_validation(test):
+    assert test('multisig_xpub_validation.py') == b'OK'

--- a/ports/stm32/boards/Passport/modules/tests/unit/multisig_xpub_validation.py
+++ b/ports/stm32/boards/Passport/modules/tests/unit/multisig_xpub_validation.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import multisig_wallet
+import stash
+
+from multisig_wallet import MultisigWallet
+from public_constants import AF_P2SH
+
+
+MY_XFP = 0x12345678
+DERIVATION = "m/48'/0'/0'/2'"
+PUBLIC_KEY = b'\x02' + (b'\x11' * 32)
+CHAIN_CODE = b'\x22' * 32
+
+
+class FakeNode:
+    def __init__(self, public_key, chain_code):
+        self._public_key = public_key
+        self._chain_code = chain_code
+
+    def depth(self):
+        return 4
+
+    def public_key(self):
+        return self._public_key
+
+    def chain_code(self):
+        return self._chain_code
+
+
+class FakeChain:
+    ctype = 'BTC'
+
+    @staticmethod
+    def serialize_public(_node, addr_fmt):
+        assert addr_fmt == AF_P2SH
+        return 'normalized-xpub'
+
+
+class FakeSensitiveValues:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        pass
+
+    @staticmethod
+    def derive_path(derivation):
+        assert derivation == DERIVATION
+        return FakeNode(PUBLIC_KEY, CHAIN_CODE)
+
+
+def check_node(node):
+    original_import_xpub = multisig_wallet.import_xpub
+    original_sensitive_values = stash.SensitiveValues
+
+    try:
+        multisig_wallet.import_xpub = lambda _xpub: (node, FakeChain, AF_P2SH)
+        stash.SensitiveValues = FakeSensitiveValues
+        xpubs = []
+        is_mine = MultisigWallet.check_xpub(
+            MY_XFP,
+            'imported-xpub',
+            DERIVATION,
+            'BTC',
+            MY_XFP,
+            xpubs,
+        )
+        return is_mine, xpubs
+    finally:
+        multisig_wallet.import_xpub = original_import_xpub
+        stash.SensitiveValues = original_sensitive_values
+
+
+is_mine, xpubs = check_node(FakeNode(PUBLIC_KEY, CHAIN_CODE))
+assert is_mine
+assert xpubs == [(MY_XFP, DERIVATION, 'normalized-xpub')]
+
+try:
+    check_node(FakeNode(PUBLIC_KEY, b'\x33' * 32))
+except AssertionError as exc:
+    assert 'wrong xpub' in str(exc)
+else:
+    raise AssertionError('Expected a substituted chain code to be rejected')
+
+return_value.write(b'OK')


### PR DESCRIPTION
## Summary

- strengthen validation of local multisig key material during import
- reject inconsistent multisig configurations before they are saved
- add focused regression coverage for the validation behavior

## Impact

Existing valid multisig configurations continue to import unchanged. Invalid local signer data is rejected earlier in the import flow.

## Testing

- Python compilation checks passed for the new test files
- Python style checks passed for the affected files
- Git diff validation passed

The Unix MicroPython unit harness was not run locally because Docker is unavailable on this machine.